### PR TITLE
⚡️ perf(edge-swipe): smooth overlay drag rendering

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,7 +15,6 @@ import { SettingsProvider } from './services/SettingsContext';
 import { EdgeSwipeProvider } from './services/edgeSwipeState';
 import { resetDragState, useEdgeSwipe } from './services/useEdgeSwipe';
 import { closeTopOverlay, getActiveOverlayId } from './services/overlayStack';
-import { computeSwipeProgress } from './services/edgeSwipeUtils';
 
 const EDGE_ZONE = 20;
 
@@ -77,6 +76,7 @@ const AppContent: React.FC = () => {
     let startY = 0;
     let edge: 'left' | 'right' | null = null;
     let active = false;
+    let draggingOverlayId: string | null = null;
     let pointerId: number | null = null;
     let captureElement: HTMLElement | null = null;
 
@@ -89,29 +89,24 @@ const AppContent: React.FC = () => {
       pointerId = null;
     };
 
+    const setDragXVar = (dragX: number) => {
+      document.documentElement.style.setProperty('--edge-swipe-drag-x', `${dragX}px`);
+    };
+
     const getScreenWidth = () => window.visualViewport?.width ?? window.innerWidth;
 
-    const shouldIgnoreTarget = (target: EventTarget | null) => {
-      if (!(target instanceof HTMLElement)) return false;
-      if (target.closest('[data-no-edge-swipe]')) return true;
-      if (target.closest('input, textarea, select, [contenteditable]')) return true;
-
-      let el: HTMLElement | null = target;
-      while (el) {
-        const style = window.getComputedStyle(el);
-        const overflowX = style.overflowX;
-        if ((overflowX === 'auto' || overflowX === 'scroll') && el.scrollWidth > el.clientWidth) {
-          return true;
-        }
-        el = el.parentElement;
+    const clampDragX = (currentEdge: 'left' | 'right', dx: number, width: number) => {
+      if (currentEdge === 'left') {
+        return Math.max(0, Math.min(width, dx));
       }
-      return false;
+      return Math.min(0, Math.max(-width, dx));
     };
+
+    const shouldCloseByDragX = (dragX: number, width: number) => Math.abs(dragX) >= 0.5 * width;
 
     const onPointerDown = (event: PointerEvent) => {
       if (event.pointerType !== 'touch' || !event.isPrimary) return;
       if (active) return;
-      if (shouldIgnoreTarget(event.target)) return;
       const { clientX, clientY } = event;
       const width = getScreenWidth();
       if (clientX <= EDGE_ZONE) edge = 'left';
@@ -130,30 +125,7 @@ const AppContent: React.FC = () => {
       if (!active || !edge) return;
       const width = getScreenWidth();
       const dx = event.clientX - startX;
-      const dy = event.clientY - startY;
-      if (Math.abs(dx) <= 2 * Math.abs(dy)) {
-        resetDragState(setDragState);
-        active = false;
-        edge = null;
-        releasePointerCapture();
-        return;
-      }
-      if ((edge === 'left' && dx <= 0) || (edge === 'right' && dx >= 0)) {
-        resetDragState(setDragState);
-        active = false;
-        edge = null;
-        releasePointerCapture();
-        return;
-      }
-      const result = computeSwipeProgress({
-        edge,
-        startX,
-        startY,
-        currentX: event.clientX,
-        currentY: event.clientY,
-        screenWidth: width,
-      });
-      if (!result.isValid) return;
+      const dragXValue = clampDragX(edge, dx, width);
       if (pointerId !== null && event.target instanceof HTMLElement) {
         const target = event.target;
         if (!target.hasPointerCapture(pointerId)) {
@@ -166,7 +138,9 @@ const AppContent: React.FC = () => {
       if (!activeOverlayId) {
         resetDragState(setDragState);
         active = false;
+        draggingOverlayId = null;
         edge = null;
+        setDragXVar(0);
         releasePointerCapture();
         return;
       }
@@ -175,40 +149,41 @@ const AppContent: React.FC = () => {
         event.preventDefault();
       }
 
-      setDragState((prev) => ({
-        ...prev,
-        isDragging: true,
-        dragX: result.dragX,
-        edge,
-        activeOverlayId,
-        snapBackX: null,
-      }));
+      setDragXVar(dragXValue);
+      if (draggingOverlayId !== activeOverlayId) {
+        draggingOverlayId = activeOverlayId;
+        setDragState((prev) => ({
+          ...prev,
+          isDragging: true,
+          dragX: 0,
+          edge,
+          activeOverlayId,
+          snapBackX: null,
+        }));
+      }
     };
 
     const onPointerEnd = (event: PointerEvent) => {
       if (pointerId !== null && event.pointerId !== pointerId) return;
       if (!active || !edge) return;
       const width = getScreenWidth();
-      const result = computeSwipeProgress({
-        edge,
-        startX,
-        startY,
-        currentX: event.clientX,
-        currentY: event.clientY,
-        screenWidth: width,
-      });
+      const dx = event.clientX - startX;
+      const dragXValue = clampDragX(edge, dx, width);
+      const shouldClose = shouldCloseByDragX(dragXValue, width);
 
       const activeOverlayId = getActiveOverlayId();
       if (!activeOverlayId) {
         resetDragState(setDragState);
         active = false;
+        draggingOverlayId = null;
         edge = null;
+        setDragXVar(0);
         releasePointerCapture();
         return;
       }
 
-      if (result.isValid && result.shouldClose) {
-        const targetX = result.dragX > 0 ? width : -width;
+      if (shouldClose) {
+        const targetX = dragXValue > 0 ? width : -width;
         setDragState((prev) => ({
           ...prev,
           closeTargetX: targetX,
@@ -216,7 +191,7 @@ const AppContent: React.FC = () => {
         }));
         closeTopOverlay({ source: 'edge-swipe', targetX });
       } else {
-        const snapX = result.dragX;
+        const snapX = dragXValue;
         setDragState((prev) => ({
           ...prev,
           isDragging: false,
@@ -237,6 +212,7 @@ const AppContent: React.FC = () => {
       }
 
       active = false;
+      draggingOverlayId = null;
       edge = null;
       releasePointerCapture();
     };
@@ -246,13 +222,14 @@ const AppContent: React.FC = () => {
       if (!active) return;
       resetDragState(setDragState);
       active = false;
+      draggingOverlayId = null;
       edge = null;
+      setDragXVar(0);
       releasePointerCapture();
     };
 
     const onTouchStart = (event: TouchEvent) => {
       if (event.touches.length !== 1) return;
-      if (shouldIgnoreTarget(event.target)) return;
       const touch = event.touches[0];
       const width = getScreenWidth();
       if (touch.clientX <= EDGE_ZONE) edge = 'left';
@@ -269,68 +246,51 @@ const AppContent: React.FC = () => {
       const width = getScreenWidth();
       const touch = event.touches[0];
       const dx = touch.clientX - startX;
-      const dy = touch.clientY - startY;
-      if (Math.abs(dx) <= 2 * Math.abs(dy)) {
-        resetDragState(setDragState);
-        active = false;
-        edge = null;
-        return;
-      }
-      if ((edge === 'left' && dx <= 0) || (edge === 'right' && dx >= 0)) {
-        resetDragState(setDragState);
-        active = false;
-        edge = null;
-        return;
-      }
-      const result = computeSwipeProgress({
-        edge,
-        startX,
-        startY,
-        currentX: touch.clientX,
-        currentY: touch.clientY,
-        screenWidth: width,
-      });
-      if (!result.isValid) return;
+      const dragXValue = clampDragX(edge, dx, width);
       const activeOverlayId = getActiveOverlayId();
       if (!activeOverlayId) {
         resetDragState(setDragState);
         active = false;
+        draggingOverlayId = null;
         edge = null;
+        setDragXVar(0);
         return;
       }
       event.preventDefault();
-      setDragState((prev) => ({
-        ...prev,
-        isDragging: true,
-        dragX: result.dragX,
-        edge,
-        activeOverlayId,
-        snapBackX: null,
-      }));
+      setDragXVar(dragXValue);
+      if (draggingOverlayId !== activeOverlayId) {
+        draggingOverlayId = activeOverlayId;
+        setDragState((prev) => ({
+          ...prev,
+          isDragging: true,
+          dragX: 0,
+          edge,
+          activeOverlayId,
+          snapBackX: null,
+        }));
+      }
     };
 
     const onTouchEnd = (event: TouchEvent) => {
       if (!active || !edge) return;
       const width = getScreenWidth();
       const touch = event.changedTouches[0];
-      const result = computeSwipeProgress({
-        edge,
-        startX,
-        startY,
-        currentX: touch.clientX,
-        currentY: touch.clientY,
-        screenWidth: width,
-      });
+      const dx = touch.clientX - startX;
+      const dragXValue = clampDragX(edge, dx, width);
+      const shouldClose = shouldCloseByDragX(dragXValue, width);
 
       const activeOverlayId = getActiveOverlayId();
       if (!activeOverlayId) {
         resetDragState(setDragState);
         active = false;
+        draggingOverlayId = null;
         edge = null;
+        setDragXVar(0);
         return;
       }
-      if (result.isValid && result.shouldClose) {
-        const targetX = result.dragX > 0 ? width : -width;
+
+      if (shouldClose) {
+        const targetX = dragXValue > 0 ? width : -width;
         setDragState((prev) => ({
           ...prev,
           closeTargetX: targetX,
@@ -338,7 +298,7 @@ const AppContent: React.FC = () => {
         }));
         closeTopOverlay({ source: 'edge-swipe', targetX });
       } else {
-        const snapX = result.dragX;
+        const snapX = dragXValue;
         setDragState((prev) => ({
           ...prev,
           isDragging: false,
@@ -358,6 +318,7 @@ const AppContent: React.FC = () => {
         });
       }
       active = false;
+      draggingOverlayId = null;
       edge = null;
     };
 
@@ -365,7 +326,9 @@ const AppContent: React.FC = () => {
       if (!active) return;
       resetDragState(setDragState);
       active = false;
+      draggingOverlayId = null;
       edge = null;
+      setDragXVar(0);
     };
 
     const supportsPointer = 'PointerEvent' in window;
@@ -385,7 +348,9 @@ const AppContent: React.FC = () => {
       if (active || isDraggingRef.current) {
         resetDragState(setDragState);
         active = false;
+        draggingOverlayId = null;
         edge = null;
+        setDragXVar(0);
         releasePointerCapture();
       }
     };
@@ -406,6 +371,7 @@ const AppContent: React.FC = () => {
       }
       window.removeEventListener('resize', onResize);
       window.visualViewport?.removeEventListener('resize', onResize);
+      setDragXVar(0);
     };
   }, [setDragState]);
 

--- a/components/AddFundModal.tsx
+++ b/components/AddFundModal.tsx
@@ -18,11 +18,13 @@ export const AddFundModal: React.FC<AddFundModalProps> = ({ isOpen, onClose, edi
   const { t } = useTranslation();
   const accounts = useLiveQuery(() => db.accounts.toArray());
   const overlayId = 'add-fund-modal';
-  const { isDragging, dragX, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
+  const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
-  const translateX = isDragging && activeOverlayId === overlayId ? dragX : 0;
+  const translateX =
+    isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
-  const transformX = closeTargetX ?? snapX ?? translateX;
+  const transformX =
+    closeTargetX !== null ? `${closeTargetX}px` : snapX !== null ? `${snapX}px` : translateX;
   const transition = closeTargetX !== null || snapX !== null ? 'transform 220ms ease' : 'none';
 
   const [query, setQuery] = useState('');
@@ -319,7 +321,7 @@ export const AddFundModal: React.FC<AddFundModalProps> = ({ isOpen, onClose, edi
     <div className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
       <div
         className="bg-white dark:bg-card-dark rounded-xl w-full max-w-md overflow-hidden shadow-2xl flex flex-col max-h-[90vh]"
-        style={{ transform: `translateX(${transformX}px)`, transition }}
+        style={{ transform: `translateX(${transformX})`, transition }}
         onTransitionEnd={() => {
           if (closeTargetX !== null) {
             setCloseTargetX(null);

--- a/components/AddWatchlistModal.tsx
+++ b/components/AddWatchlistModal.tsx
@@ -21,11 +21,13 @@ export const AddWatchlistModal: React.FC<AddWatchlistModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const overlayId = 'add-watchlist-modal';
-  const { isDragging, dragX, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
+  const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
-  const translateX = isDragging && activeOverlayId === overlayId ? dragX : 0;
+  const translateX =
+    isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
-  const transformX = closeTargetX ?? snapX ?? translateX;
+  const transformX =
+    closeTargetX !== null ? `${closeTargetX}px` : snapX !== null ? `${snapX}px` : translateX;
   const transition = closeTargetX !== null || snapX !== null ? 'transform 220ms ease' : 'none';
   const [type, setType] = useState<'fund' | 'index'>('fund');
   const [code, setCode] = useState('');
@@ -202,7 +204,7 @@ export const AddWatchlistModal: React.FC<AddWatchlistModalProps> = ({
         exit={{ opacity: 0 }}
       >
         <div
-          style={{ transform: `translateX(${transformX}px)`, transition }}
+          style={{ transform: `translateX(${transformX})`, transition }}
           onTransitionEnd={() => {
             if (closeTargetX !== null) {
               setCloseTargetX(null);

--- a/components/AdjustPositionModal.tsx
+++ b/components/AdjustPositionModal.tsx
@@ -20,11 +20,13 @@ export const AdjustPositionModal: React.FC<AdjustPositionModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const overlayId = 'adjust-position-modal';
-  const { isDragging, dragX, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
+  const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
-  const translateX = isDragging && activeOverlayId === overlayId ? dragX : 0;
+  const translateX =
+    isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
-  const transformX = closeTargetX ?? snapX ?? translateX;
+  const transformX =
+    closeTargetX !== null ? `${closeTargetX}px` : snapX !== null ? `${snapX}px` : translateX;
   const transition = closeTargetX !== null || snapX !== null ? 'transform 220ms ease' : 'none';
 
   const [type, setType] = useState<'buy' | 'sell'>('buy');
@@ -137,7 +139,7 @@ export const AdjustPositionModal: React.FC<AdjustPositionModalProps> = ({
     <div className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
       <div
         className="bg-white dark:bg-card-dark rounded-xl w-full max-w-md overflow-hidden shadow-2xl flex flex-col max-h-[90vh]"
-        style={{ transform: `translateX(${transformX}px)`, transition }}
+        style={{ transform: `translateX(${transformX})`, transition }}
         onTransitionEnd={() => {
           if (closeTargetX !== null) {
             setCloseTargetX(null);

--- a/components/FundDetail.tsx
+++ b/components/FundDetail.tsx
@@ -194,12 +194,14 @@ export const FundDetail: React.FC<FundDetailProps> = ({
   const isDark = theme === 'dark';
   const fundId = fund.id ?? fund.code;
   const overlayId = `fund-detail:${fundId}`;
-  const { isDragging, dragX, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
+  const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
   const [isEdgeClosing, setIsEdgeClosing] = useState(false);
-  const translateX = isDragging && activeOverlayId === overlayId ? dragX : 0;
+  const translateX =
+    isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
-  const transformX = closeTargetX ?? snapX ?? translateX;
+  const transformX =
+    closeTargetX !== null ? `${closeTargetX}px` : snapX !== null ? `${snapX}px` : translateX;
   const transition = closeTargetX !== null || snapX !== null ? 'transform 220ms ease' : 'none';
 
   // snap-back animation is driven by App.tsx via snapBackX
@@ -694,8 +696,8 @@ export const FundDetail: React.FC<FundDetailProps> = ({
         请勿随意移除此样式，除非同步验证桌面端详情页宽度与居中行为。
       */}
       <div
-        className="w-full md:flex md:justify-center"
-        style={{ transform: `translateX(${transformX}px)`, transition }}
+        className="w-full h-full md:flex md:justify-center"
+        style={{ transform: `translateX(${transformX})`, transition }}
         onTransitionEnd={(event) => {
           if (event.propertyName !== 'transform') return;
           if (closeTargetX !== null) {
@@ -709,7 +711,7 @@ export const FundDetail: React.FC<FundDetailProps> = ({
         }}
       >
         <motion.div
-          className="bg-gray-50 dark:bg-app-bg-dark flex flex-col w-full h-full md:h-[calc(100vh-2rem)] lg:h-[calc(100vh-4rem)] md:w-[50vw] md:min-w-[960px] md:rounded-xl md:shadow-2xl md:border md:border-gray-200 dark:md:border-border-dark overflow-hidden relative"
+          className="bg-gray-50 dark:bg-app-bg-dark flex flex-col min-h-0 w-full h-full md:h-[calc(100vh-2rem)] lg:h-[calc(100vh-4rem)] md:w-[50vw] md:min-w-[960px] md:rounded-xl md:shadow-2xl md:border md:border-gray-200 dark:md:border-border-dark overflow-hidden relative"
           onClick={(e) => e.stopPropagation()}
           initial={isDesktop ? { opacity: 0, scale: 0.95, y: 20 } : { opacity: 1, x: '100%' }}
           animate={isDesktop ? { opacity: 1, scale: 1, y: 0 } : { opacity: 1, x: 0 }}
@@ -739,7 +741,7 @@ export const FundDetail: React.FC<FundDetailProps> = ({
             <div className="w-10"></div>
           </div>
 
-          <div className="flex-1 overflow-y-auto flex flex-col no-scrollbar bg-gray-50 dark:bg-app-bg-dark">
+          <div className="flex-1 min-h-0 overflow-y-auto overscroll-y-contain touch-pan-y flex flex-col no-scrollbar bg-gray-50 dark:bg-app-bg-dark">
             {/* Hero Card */}
             <div className="bg-white dark:bg-card-dark p-6 mb-2 transition-colors">
               <div className="text-gray-500 dark:text-gray-400 text-xs mb-1">

--- a/components/ScannerModal.tsx
+++ b/components/ScannerModal.tsx
@@ -42,12 +42,14 @@ export const ScannerModal: React.FC<ScannerModalProps> = ({ isOpen, onClose }) =
   const fileInputRef = useRef<HTMLInputElement>(null);
   const lastAutoValidateSignatureRef = useRef('');
   const overlayId = 'scanner-modal';
-  const { isDragging, dragX, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
+  const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
   const overlayOpen = isOpen || isReviewing;
-  const translateX = isDragging && activeOverlayId === overlayId ? dragX : 0;
+  const translateX =
+    isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
-  const transformX = closeTargetX ?? snapX ?? translateX;
+  const transformX =
+    closeTargetX !== null ? `${closeTargetX}px` : snapX !== null ? `${snapX}px` : translateX;
   const transition = closeTargetX !== null || snapX !== null ? 'transform 220ms ease' : 'none';
 
   const { t } = useTranslation();
@@ -347,7 +349,7 @@ export const ScannerModal: React.FC<ScannerModalProps> = ({ isOpen, onClose }) =
             transition={{ duration: 0.2 }}
           >
             <div
-              style={{ transform: `translateX(${transformX}px)`, transition }}
+              style={{ transform: `translateX(${transformX})`, transition }}
               onTransitionEnd={() => {
                 if (closeTargetX !== null) {
                   setCloseTargetX(null);
@@ -453,7 +455,7 @@ export const ScannerModal: React.FC<ScannerModalProps> = ({ isOpen, onClose }) =
             transition={{ duration: 0.2 }}
           >
             <div
-              style={{ transform: `translateX(${transformX}px)`, transition }}
+              style={{ transform: `translateX(${transformX})`, transition }}
               onTransitionEnd={() => {
                 if (closeTargetX !== null) {
                   setCloseTargetX(null);

--- a/components/TransactionHistoryModal.tsx
+++ b/components/TransactionHistoryModal.tsx
@@ -19,11 +19,13 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
 }) => {
   const { t } = useTranslation();
   const overlayId = 'transaction-history-modal';
-  const { isDragging, dragX, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
+  const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
-  const translateX = isDragging && activeOverlayId === overlayId ? dragX : 0;
+  const translateX =
+    isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
-  const transformX = closeTargetX ?? snapX ?? translateX;
+  const transformX =
+    closeTargetX !== null ? `${closeTargetX}px` : snapX !== null ? `${snapX}px` : translateX;
   const transition = closeTargetX !== null || snapX !== null ? 'transform 220ms ease' : 'none';
 
   const handleClose = useCallback(() => {
@@ -79,7 +81,7 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm sm:p-4 opacity-100 transition-opacity">
       <div
         className="bg-white dark:bg-card-dark w-full sm:w-[480px] sm:rounded-2xl rounded-t-2xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh] transition-transform translate-y-0 relative"
-        style={{ transform: `translateX(${transformX}px)`, transition }}
+        style={{ transform: `translateX(${transformX})`, transition }}
         onTransitionEnd={() => {
           if (closeTargetX !== null) {
             setCloseTargetX(null);

--- a/components/WelcomeModal.tsx
+++ b/components/WelcomeModal.tsx
@@ -26,13 +26,15 @@ export const WelcomeModal: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const overlayId = 'welcome-modal';
-  const { isDragging, dragX, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
+  const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
   const closeTimeoutRef = useRef<number | null>(null);
   const openRafRef = useRef<number | null>(null);
-  const translateX = isDragging && activeOverlayId === overlayId ? dragX : 0;
+  const translateX =
+    isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
-  const transformX = closeTargetX ?? snapX ?? translateX;
+  const transformX =
+    closeTargetX !== null ? `${closeTargetX}px` : snapX !== null ? `${snapX}px` : translateX;
   const transition = closeTargetX !== null || snapX !== null ? 'transform 220ms ease' : undefined;
   const modalOffsetY = isVisible ? 0 : 10;
   const modalScale = isVisible ? 1 : 0.96;
@@ -177,7 +179,7 @@ export const WelcomeModal: React.FC = () => {
         data-testid="welcome-modal-card"
         className={`bg-white dark:bg-card-dark rounded-2xl w-full max-w-sm overflow-hidden shadow-2xl max-h-[90vh] flex flex-col transition-all duration-[260ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform ${isVisible ? 'opacity-100' : 'opacity-0'}`}
         style={{
-          transform: `translate3d(${transformX}px, ${modalOffsetY}px, 0) scale(${modalScale})`,
+          transform: `translate3d(${transformX}, ${modalOffsetY}px, 0) scale(${modalScale})`,
           transition,
         }}
         onTransitionEnd={() => {


### PR DESCRIPTION
## Summary
- move edge-swipe drag updates to a CSS variable to reduce context-driven rerenders during gesture movement
- keep overlay snap-back and close release animations consistent after drag end
- keep full-screen fund detail scroll behavior stable while preserving edge-swipe interactions

## Verification
- npm run build