### PR TITLE
fix(account): preserve IME composition when editing account names

### DIFF
--- a/components/AccountManagerModal.test.tsx
+++ b/components/AccountManagerModal.test.tsx
@@ -1,0 +1,78 @@
+/// <reference types="vitest/globals" />
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AccountManagerModal } from './AccountManagerModal';
+import { useLiveQuery } from 'dexie-react-hooks';
+
+const mockedUseLiveQuery = vi.mocked(useLiveQuery);
+
+vi.mock('dexie-react-hooks', () => ({
+  useLiveQuery: vi.fn(() => []),
+}));
+
+vi.mock('../services/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../services/db', () => ({
+  db: {
+    accounts: {
+      add: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+      toArray: vi.fn(async () => []),
+    },
+    funds: {
+      where: vi.fn(() => ({
+        equals: vi.fn(() => ({
+          modify: vi.fn(),
+        })),
+      })),
+    },
+    transaction: vi.fn(
+      async (_mode: string, _accounts: unknown, _funds: unknown, fn: () => Promise<void>) => {
+        await fn();
+      },
+    ),
+  },
+}));
+
+describe('AccountManagerModal 输入法兼容', () => {
+  it('编辑账户时，拼音输入进行中不应被4字限制截断', () => {
+    mockedUseLiveQuery.mockReturnValue([
+      {
+        id: 1,
+        name: '账户A',
+        isDefault: false,
+      },
+    ]);
+
+    render(<AccountManagerModal isOpen={true} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }));
+
+    const input = screen.getByDisplayValue('账户A');
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'pinyinabcdef' } });
+    expect(input).toHaveValue('pinyinabcdef');
+
+    fireEvent.compositionEnd(input, { target: { value: '编辑账户超长' } });
+    expect(input).toHaveValue('编辑账户');
+  });
+
+  it('新增账户时，拼音输入进行中不应被4字限制截断', () => {
+    mockedUseLiveQuery.mockReturnValue([]);
+
+    render(<AccountManagerModal isOpen={true} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.addAccount' }));
+    const input = screen.getByPlaceholderText('common.accountName');
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'pinyinabcdef' } });
+    expect(input).toHaveValue('pinyinabcdef');
+
+    fireEvent.compositionEnd(input, { target: { value: '中文测试超长' } });
+    expect(input).toHaveValue('中文测试');
+  });
+});

--- a/components/AccountManagerModal.tsx
+++ b/components/AccountManagerModal.tsx
@@ -17,10 +17,12 @@ export const AccountManagerModal: React.FC<AccountManagerModalProps> = ({ isOpen
   // Add State
   const [newAccountName, setNewAccountName] = useState('');
   const [isAdding, setIsAdding] = useState(false);
+  const [isComposingNewName, setIsComposingNewName] = useState(false);
 
   // Edit State
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editName, setEditName] = useState('');
+  const [isComposingEditName, setIsComposingEditName] = useState(false);
 
   if (!isOpen) return null;
 
@@ -98,8 +100,18 @@ export const AccountManagerModal: React.FC<AccountManagerModalProps> = ({ isOpen
                     <input
                       autoFocus
                       value={editName}
-                      maxLength={4}
-                      onChange={(e) => setEditName(normalizeAccountName(e.target.value))}
+                      onCompositionStart={() => setIsComposingEditName(true)}
+                      onCompositionEnd={(e) => {
+                        setIsComposingEditName(false);
+                        setEditName(normalizeAccountName(e.currentTarget.value));
+                      }}
+                      onChange={(e) => {
+                        if (isComposingEditName) {
+                          setEditName(stripLineBreaks(e.target.value));
+                          return;
+                        }
+                        setEditName(normalizeAccountName(e.target.value));
+                      }}
                       className="flex-1 px-2 py-1 border border-blue-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 whitespace-nowrap"
                     />
                     <button
@@ -157,8 +169,18 @@ export const AccountManagerModal: React.FC<AccountManagerModalProps> = ({ isOpen
                 autoFocus
                 type="text"
                 value={newAccountName}
-                maxLength={4}
-                onChange={(e) => setNewAccountName(normalizeAccountName(e.target.value))}
+                onCompositionStart={() => setIsComposingNewName(true)}
+                onCompositionEnd={(e) => {
+                  setIsComposingNewName(false);
+                  setNewAccountName(normalizeAccountName(e.currentTarget.value));
+                }}
+                onChange={(e) => {
+                  if (isComposingNewName) {
+                    setNewAccountName(stripLineBreaks(e.target.value));
+                    return;
+                  }
+                  setNewAccountName(normalizeAccountName(e.target.value));
+                }}
                 placeholder={t('common.accountName')}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-blue-500 whitespace-nowrap"
               />
@@ -192,6 +214,8 @@ export const AccountManagerModal: React.FC<AccountManagerModalProps> = ({ isOpen
   );
 };
 const normalizeAccountName = (value: string) => {
-  const noLineBreak = value.replace(/[\r\n]/g, '').trim();
+  const noLineBreak = stripLineBreaks(value).trim();
   return Array.from(noLineBreak).slice(0, 4).join('');
 };
+
+const stripLineBreaks = (value: string) => value.replace(/[\r\n]/g, '');


### PR DESCRIPTION
## Summary
- keep raw input during IME composition in account add/edit fields
- normalize and apply 4-character limit only after composition ends
- add regression tests for IME composition behavior in AccountManagerModal

## Test Plan
- npm run test -- components/AccountManagerModal.test.tsx