### PR TITLE
feat(transaction): support deleting settled fund transactions

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -330,6 +330,28 @@ export const Dashboard: React.FC = () => {
     }
   };
 
+  const handleTransactionsDeleted = async (affectedFundIds: number[]) => {
+    if (affectedFundIds.length === 0) return;
+
+    const refreshedFunds = await db.funds.bulkGet(affectedFundIds);
+    const refreshedFundMap = new Map<number, Fund>();
+    refreshedFunds.forEach((item) => {
+      if (item?.id != null) {
+        refreshedFundMap.set(item.id, item);
+      }
+    });
+
+    setSelectedFund((prev) => {
+      if (!prev?.id || !affectedFundIds.includes(prev.id)) return prev;
+      return refreshedFundMap.get(prev.id) ?? null;
+    });
+
+    setHistoryFund((prev) => {
+      if (!prev?.id || !affectedFundIds.includes(prev.id)) return prev;
+      return refreshedFundMap.get(prev.id) ?? null;
+    });
+  };
+
   return (
     <div
       className="pb-36 md:pb-24 bg-app-bg dark:bg-app-bg-dark min-h-full"
@@ -853,6 +875,7 @@ export const Dashboard: React.FC = () => {
           isOpen={!!historyFund}
           onClose={() => setHistoryFund(null)}
           fund={historyFund}
+          onTransactionsDeleted={handleTransactionsDeleted}
         />
       )}
       <AiHoldingsAnalysisModal

--- a/components/FundDetail.test.tsx
+++ b/components/FundDetail.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom';
-import { readFileSync } from 'node:fs';
 import { render, screen } from '@testing-library/react';
 import { expect, it } from 'vitest';
 import { TradeMarkerLegend } from './TradeMarkerLegend';
 import {
+  buildTradeMarkersFromTransactions,
   buildChartOption,
   buildFundSeries,
   buildLegendViewModel,
@@ -11,9 +11,45 @@ import {
   getTradeLegendLabels,
 } from './fundDetailChartUtils';
 
-it('keeps desktop detail wrapper full-width centering classes', () => {
-  const source = readFileSync(`${process.cwd()}/components/FundDetail.tsx`, 'utf-8');
-  expect(source).toContain('className="w-full md:flex md:justify-center"');
+it('uses unified transaction marker builder to reflect deletion changes', () => {
+  const dates = ['2026-03-20', '2026-03-21'];
+  const fundData = [1, 2];
+  const transactions = [
+    {
+      id: 'tx-buy',
+      type: 'buy' as const,
+      date: '2026-03-20',
+      time: 'before15' as const,
+      amount: 100,
+      settlementDate: '2026-03-21',
+      settled: true,
+    },
+    {
+      id: 'tx-sell',
+      type: 'sell' as const,
+      date: '2026-03-21',
+      time: 'before15' as const,
+      amount: 100,
+      settlementDate: '2026-03-22',
+      settled: false,
+    },
+  ];
+
+  const beforeDelete = buildTradeMarkersFromTransactions({
+    dates,
+    fundData,
+    transactions,
+    holdingShares: 0,
+  });
+  const afterDelete = buildTradeMarkersFromTransactions({
+    dates,
+    fundData,
+    transactions: transactions.filter((tx) => tx.id !== 'tx-sell'),
+    holdingShares: 100,
+  });
+
+  expect(beforeDelete.map((m) => m.name)).toEqual(['buy', 'sell']);
+  expect(afterDelete.map((m) => m.name)).toEqual(['buy']);
 });
 
 it('marks buy with red dot', () => {

--- a/components/FundDetail.tsx
+++ b/components/FundDetail.tsx
@@ -9,7 +9,13 @@ import type {
 } from '../types';
 import { Icons } from './Icon';
 import { TradeMarkerLegend } from './TradeMarkerLegend';
-import { buildChartOption, buildLegendViewModel, buildTradeMarkers } from './fundDetailChartUtils';
+import {
+  TRADE_MARKER_COLORS,
+  buildChartOption,
+  buildLegendViewModel,
+  buildTradeMarkersFromTransactions,
+} from './fundDetailChartUtils';
+import type { MarkPointDatum } from './fundDetailChartUtils';
 import { formatPct, getSignColor, formatSignedCurrency } from '../services/financeUtils';
 import { useTranslation } from '../services/i18n';
 import { useTheme } from '../services/ThemeContext';
@@ -573,15 +579,48 @@ export const FundDetail: React.FC<FundDetailProps> = ({
       return html;
     };
 
-    const markers = buildTradeMarkers({
-      dates,
-      fundData,
-      isWatchlist: Boolean(anchorDate),
-      buyDate: fund.buyDate,
-      anchorDate,
-      pendingTransactions: fund.pendingTransactions,
-      holdingShares: fund.holdingShares,
-    });
+    const markers = (() => {
+      if (anchorDate) {
+        const anchorIdx = dates.indexOf(anchorDate);
+        if (anchorIdx === -1) return [];
+        return [
+          {
+            name: 'anchor',
+            coord: [anchorDate, fundData[anchorIdx] ?? null] as [string, number | null],
+            symbol: 'circle',
+            symbolSize: 8,
+            label: { show: false },
+            itemStyle: { color: TRADE_MARKER_COLORS.anchor },
+          },
+        ];
+      }
+
+      const points: MarkPointDatum[] = [];
+
+      if (fund.buyDate) {
+        const buyIdx = dates.indexOf(fund.buyDate);
+        if (buyIdx !== -1) {
+          points.push({
+            name: 'buy',
+            coord: [fund.buyDate, fundData[buyIdx] ?? null],
+            symbol: 'circle',
+            symbolSize: 8,
+            label: { show: false },
+            itemStyle: { color: TRADE_MARKER_COLORS.buy },
+          });
+        }
+      }
+
+      points.push(
+        ...buildTradeMarkersFromTransactions({
+          dates,
+          fundData,
+          transactions: fund.pendingTransactions,
+          holdingShares: fund.holdingShares,
+        }),
+      );
+      return points;
+    })();
 
     const option = buildChartOption({
       fundName: fund.name,

--- a/components/TransactionHistoryModal.delete.test.tsx
+++ b/components/TransactionHistoryModal.delete.test.tsx
@@ -1,0 +1,167 @@
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Fund, PendingTransaction } from '../types';
+import { TransactionHistoryModal } from './TransactionHistoryModal';
+
+const mockedDeps = vi.hoisted(() => ({
+  t: (key: string) => {
+    const dict: Record<string, string> = {
+      'common.transactionHistory': '交易记录',
+      'common.noHistory': '暂无交易记录',
+      'common.undo': '撤销',
+      'common.delete': '删除',
+      'common.cancelConfirm': '确定要撤销这笔在途交易吗？',
+      'common.linkedDeleteConfirm': '删除该调仓记录将同时删除关联记录，是否继续？',
+      'common.linkedDeleteOverLimit': '关联记录数量异常，已阻止删除，请稍后重试。',
+      'common.before15': '15:00 前',
+      'common.after15': '15:00 后',
+      'common.addPosition': '加仓',
+      'common.reducePosition': '减仓',
+      'common.transferOutLabel': '调仓转出',
+      'common.transferInLabel': '调仓转入',
+      'common.linkedTransfer': '关联调仓',
+      'common.inTransit': '在途',
+      'common.settled': '已确认',
+    };
+    return dict[key] ?? key;
+  },
+  deletePendingTransaction: vi.fn(),
+}));
+
+vi.mock('../services/i18n', () => ({
+  useTranslation: () => ({ t: mockedDeps.t }),
+}));
+
+vi.mock('../services/db', () => ({
+  deletePendingTransaction: mockedDeps.deletePendingTransaction,
+}));
+
+vi.mock('../services/useEdgeSwipe', () => ({
+  resetDragState: vi.fn(),
+  useEdgeSwipe: () => ({
+    isDragging: false,
+    activeOverlayId: null,
+    setDragState: vi.fn(),
+    snapBackX: null,
+  }),
+}));
+
+vi.mock('../services/overlayRegistration', () => ({
+  useOverlayRegistration: vi.fn(),
+}));
+
+const buildTx = (overrides?: Partial<PendingTransaction>): PendingTransaction => ({
+  id: 'tx-1',
+  type: 'buy',
+  date: '2026-03-20',
+  time: 'before15',
+  amount: 100,
+  settlementDate: '2026-03-21',
+  settled: false,
+  ...overrides,
+});
+
+const buildFund = (txs: PendingTransaction[]): Fund => ({
+  id: 1,
+  code: '000001',
+  name: '测试基金',
+  platform: '天天基金',
+  holdingShares: 100,
+  costPrice: 1,
+  currentNav: 1,
+  lastUpdate: '2026-03-20',
+  dayChangePct: 0,
+  dayChangeVal: 0,
+  pendingTransactions: txs,
+});
+
+describe('TransactionHistoryModal delete flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    mockedDeps.deletePendingTransaction.mockResolvedValue({
+      deletedCount: 1,
+      affectedFundIds: [1],
+      linkedDelete: false,
+    });
+  });
+
+  it('splits action copy by settled status (撤销/删除)', () => {
+    const fund = buildFund([
+      buildTx({ id: 'u1', settled: false }),
+      buildTx({ id: 's1', settled: true, type: 'sell' }),
+    ]);
+
+    render(<TransactionHistoryModal isOpen onClose={vi.fn()} fund={fund} />);
+
+    expect(screen.getByRole('button', { name: '撤销' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '删除' })).toBeTruthy();
+  });
+
+  it('calls deletePendingTransaction for delete action', async () => {
+    const onTransactionsDeleted = vi.fn();
+    const fund = buildFund([buildTx({ id: 'tx-delete', settled: true, type: 'sell' })]);
+
+    render(
+      <TransactionHistoryModal
+        isOpen
+        onClose={vi.fn()}
+        fund={fund}
+        onTransactionsDeleted={onTransactionsDeleted}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '删除' }));
+
+    await waitFor(() => {
+      expect(mockedDeps.deletePendingTransaction).toHaveBeenCalledWith({
+        fundId: 1,
+        txId: 'tx-delete',
+        transferId: undefined,
+        type: 'sell',
+      });
+    });
+    expect(onTransactionsDeleted).toHaveBeenCalledWith([1]);
+  });
+
+  it('uses linked confirmation copy for transfer records', async () => {
+    const fund = buildFund([
+      buildTx({ id: 'tx-transfer', type: 'transferOut', transferId: 'tr-1', settled: true }),
+    ]);
+
+    render(<TransactionHistoryModal isOpen onClose={vi.fn()} fund={fund} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '删除' }));
+
+    expect(globalThis.confirm).toHaveBeenCalledWith('删除该调仓记录将同时删除关联记录，是否继续？');
+    await waitFor(() => {
+      expect(mockedDeps.deletePendingTransaction).toHaveBeenCalledWith({
+        fundId: 1,
+        txId: 'tx-transfer',
+        transferId: 'tr-1',
+        type: 'transferOut',
+      });
+    });
+  });
+
+  it('shows user-visible feedback for LINKED_DELETE_OVER_LIMIT', async () => {
+    mockedDeps.deletePendingTransaction.mockResolvedValue({
+      code: 'LINKED_DELETE_OVER_LIMIT',
+      userMessageKey: 'common.linkedDeleteOverLimit',
+      logFields: { transferId: 'tr-over', matchedCount: 3, fundId: 1 },
+      deletedCount: 0,
+      affectedFundIds: [],
+      linkedDelete: true,
+    });
+    const fund = buildFund([
+      buildTx({ id: 'tx-over', type: 'transferOut', transferId: 'tr-over', settled: false }),
+    ]);
+
+    render(<TransactionHistoryModal isOpen onClose={vi.fn()} fund={fund} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '撤销' }));
+
+    expect(await screen.findByText('关联记录数量异常，已阻止删除，请稍后重试。')).toBeTruthy();
+  });
+});

--- a/components/TransactionHistoryModal.tsx
+++ b/components/TransactionHistoryModal.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import type { Fund, PendingTransaction } from '../types';
 import { useTranslation } from '../services/i18n';
 import { Icons } from './Icon';
-import { db } from '../services/db';
+import { deletePendingTransaction } from '../services/db';
 import { resetDragState, useEdgeSwipe } from '../services/useEdgeSwipe';
 import { useOverlayRegistration } from '../services/overlayRegistration';
 
@@ -10,17 +10,21 @@ interface TransactionHistoryModalProps {
   isOpen: boolean;
   onClose: () => void;
   fund: Fund;
+  onTransactionsDeleted?: (affectedFundIds: number[]) => void;
 }
 
 export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = ({
   isOpen,
   onClose,
   fund,
+  onTransactionsDeleted,
 }) => {
   const { t } = useTranslation();
   const overlayId = 'transaction-history-modal';
   const { isDragging, activeOverlayId, setDragState, snapBackX } = useEdgeSwipe();
   const [closeTargetX, setCloseTargetX] = useState<number | null>(null);
+  const [transactions, setTransactions] = useState<PendingTransaction[]>(fund.pendingTransactions || []);
+  const [deleteFeedback, setDeleteFeedback] = useState<string | null>(null);
   const translateX =
     isDragging && activeOverlayId === overlayId ? 'var(--edge-swipe-drag-x, 0px)' : '0px';
   const snapX = activeOverlayId === overlayId ? snapBackX : null;
@@ -53,10 +57,15 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
     };
   }, [activeOverlayId, overlayId, setDragState]);
 
+  useEffect(() => {
+    setTransactions(fund.pendingTransactions || []);
+    setDeleteFeedback(null);
+  }, [fund.id, fund.pendingTransactions]);
+
   if (!isOpen) return null;
 
   // 按操作日期倒序排列
-  const transactions = [...(fund.pendingTransactions || [])].sort(
+  const sortedTransactions = [...transactions].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
   );
 
@@ -76,20 +85,64 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
     return '--';
   };
 
-  const handleCancel = async (txId: string) => {
-    if (!window.confirm(t('common.cancelConfirm') || '确定要撤销这笔在途交易吗？')) {
+  const isTransferType = (type: PendingTransaction['type']) => {
+    return type === 'transferOut' || type === 'transferIn';
+  };
+
+  const handleDelete = async (tx: PendingTransaction) => {
+    if (!fund.id) {
       return;
     }
 
-    const newPending = (fund.pendingTransactions || []).filter((tx) => tx.id !== txId);
+    const confirmMessage = tx.transferId && isTransferType(tx.type)
+      ? t('common.linkedDeleteConfirm') || '删除该调仓记录将同时删除关联记录，是否继续？'
+      : tx.settled
+        ? t('common.deleteConfirm') || '确定要删除这条已确认交易记录吗？'
+        : t('common.cancelConfirm') || '确定要撤销这笔在途交易吗？';
+
+    if (!window.confirm(confirmMessage)) {
+      return;
+    }
+
+    setDeleteFeedback(null);
 
     try {
-      await db.funds.update(fund.id!, {
-        pendingTransactions: newPending,
+      const result = await deletePendingTransaction({
+        fundId: fund.id,
+        txId: tx.id,
+        transferId: tx.transferId,
+        type: tx.type,
       });
-      // 不关闭弹窗，因为可能还要操作别的记录
+
+      if ('code' in result && result.code === 'LINKED_DELETE_OVER_LIMIT') {
+        setDeleteFeedback(
+          t(result.userMessageKey) || '关联记录数量异常，已阻止删除，请稍后重试。',
+        );
+        return;
+      }
+
+      if (result.deletedCount <= 0) {
+        return;
+      }
+
+      const isCurrentFundAffected = result.affectedFundIds.includes(fund.id);
+      if (isCurrentFundAffected) {
+        setTransactions((prev) => {
+          if (tx.transferId && isTransferType(tx.type)) {
+            return prev.filter(
+              (item) => !(item.transferId === tx.transferId && isTransferType(item.type)),
+            );
+          }
+          return prev.filter((item) => item.id !== tx.id);
+        });
+      }
+
+      if (result.affectedFundIds.length > 0) {
+        onTransactionsDeleted?.(result.affectedFundIds);
+      }
     } catch (e) {
-      console.error('Failed to cancel transaction', e);
+      console.error('Failed to delete transaction', e);
+      setDeleteFeedback(t('common.deleteFailed') || '删除失败，请稍后重试');
     }
   };
 
@@ -130,14 +183,19 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
 
         {/* 列表内容区 */}
         <div className="p-4 overflow-y-auto flex-grow bg-gray-50/50 dark:bg-transparent">
-          {transactions.length === 0 ? (
+          {deleteFeedback && (
+            <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-200">
+              {deleteFeedback}
+            </div>
+          )}
+          {sortedTransactions.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-gray-400">
               <Icons.Grid size={40} className="mb-3 opacity-20" />
               <p className="text-sm">{t('common.noHistory') || '暂无交易记录'}</p>
             </div>
           ) : (
             <div className="space-y-3">
-              {transactions.map((tx) => (
+              {sortedTransactions.map((tx) => (
                 <div
                   key={tx.id}
                   className="bg-white dark:bg-white/5 border border-gray-100 dark:border-border-dark rounded-xl p-4 shadow-sm flex items-center justify-between"
@@ -190,14 +248,12 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
                     </div>
                   </div>
 
-                  {!tx.settled && (
-                    <button
-                      onClick={() => handleCancel(tx.id)}
-                      className="px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 hover:bg-red-50 hover:text-red-500 dark:bg-white/10 dark:text-gray-300 dark:hover:bg-red-900/30 dark:hover:text-red-400 rounded-lg transition-colors border border-transparent hover:border-red-100 dark:hover:border-red-900/50"
-                    >
-                      {t('common.undo') || '撤销'}
-                    </button>
-                  )}
+                  <button
+                    onClick={() => handleDelete(tx)}
+                    className="px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 hover:bg-red-50 hover:text-red-500 dark:bg-white/10 dark:text-gray-300 dark:hover:bg-red-900/30 dark:hover:text-red-400 rounded-lg transition-colors border border-transparent hover:border-red-100 dark:hover:border-red-900/50"
+                  >
+                    {tx.settled ? t('common.delete') || '删除' : t('common.undo') || '撤销'}
+                  </button>
                 </div>
               ))}
             </div>

--- a/components/fundDetailChartUtils.marker.test.ts
+++ b/components/fundDetailChartUtils.marker.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { PendingTransaction } from '../types';
+import { buildTradeMarkersFromTransactions } from './fundDetailChartUtils';
+
+const buildTx = (overrides: Partial<PendingTransaction>): PendingTransaction => ({
+  id: 'tx-1',
+  type: 'buy',
+  date: '2026-03-20',
+  time: 'before15',
+  amount: 100,
+  settlementDate: '2026-03-21',
+  settled: false,
+  ...overrides,
+});
+
+describe('buildTradeMarkersFromTransactions', () => {
+  it('maps all transaction types into markers', () => {
+    const markers = buildTradeMarkersFromTransactions({
+      dates: ['2026-03-20', '2026-03-21', '2026-03-22', '2026-03-23'],
+      fundData: [1, 2, 3, 4],
+      transactions: [
+        buildTx({ id: 'b-1', type: 'buy', date: '2026-03-20' }),
+        buildTx({ id: 's-1', type: 'sell', date: '2026-03-21' }),
+        buildTx({ id: 'to-1', type: 'transferOut', date: '2026-03-22', outShares: 8, amount: 8 }),
+        buildTx({ id: 'ti-1', type: 'transferIn', date: '2026-03-23' }),
+      ],
+      holdingShares: 10,
+    });
+
+    expect(markers.map((m) => m.name)).toEqual(['buy', 'sell', 'sell', 'buy']);
+    expect(markers.map((m) => m.coord[0])).toEqual([
+      '2026-03-20',
+      '2026-03-21',
+      '2026-03-22',
+      '2026-03-23',
+    ]);
+  });
+
+  it('includes both settled and unsettled transactions', () => {
+    const markers = buildTradeMarkersFromTransactions({
+      dates: ['2026-03-20', '2026-03-21'],
+      fundData: [1, 2],
+      transactions: [
+        buildTx({ id: 'settled-buy', type: 'buy', date: '2026-03-20', settled: true }),
+        buildTx({ id: 'unsettled-sell', type: 'sell', date: '2026-03-21', settled: false }),
+      ],
+      holdingShares: 10,
+    });
+
+    expect(markers).toHaveLength(2);
+    expect(markers.map((m) => m.coord[0])).toEqual(['2026-03-20', '2026-03-21']);
+  });
+
+  it('keeps stable ordering for same day by before15 -> after15 -> id', () => {
+    const markers = buildTradeMarkersFromTransactions({
+      dates: ['2026-03-20'],
+      fundData: [1],
+      transactions: [
+        buildTx({ id: 'tx-b', type: 'sell', date: '2026-03-20', time: 'before15' }),
+        buildTx({ id: 'tx-d', type: 'buy', date: '2026-03-20', time: 'after15' }),
+        buildTx({ id: 'tx-a', type: 'buy', date: '2026-03-20', time: 'before15' }),
+        buildTx({ id: 'tx-c', type: 'sell', date: '2026-03-20', time: 'after15' }),
+      ],
+      holdingShares: 10,
+    });
+
+    expect(markers.map((m) => m.name)).toEqual(['buy', 'sell', 'sell', 'buy']);
+    expect(markers.map((m) => m.coord[0])).toEqual([
+      '2026-03-20',
+      '2026-03-20',
+      '2026-03-20',
+      '2026-03-20',
+    ]);
+  });
+});

--- a/components/fundDetailChartUtils.ts
+++ b/components/fundDetailChartUtils.ts
@@ -70,9 +70,93 @@ const compareTransactions = (a: PendingTransaction, b: PendingTransaction) => {
   if (a.date === b.date) {
     const aTime = a.time === 'after15' ? 1 : 0;
     const bTime = b.time === 'after15' ? 1 : 0;
+    if (aTime === bTime) {
+      return a.id.localeCompare(b.id);
+    }
     return aTime - bTime;
   }
   return a.date.localeCompare(b.date);
+};
+
+type BuildTradeMarkersFromTransactionsInput = {
+  dates: string[];
+  fundData: Array<number | null | undefined>;
+  transactions?: PendingTransaction[];
+  holdingShares: number;
+};
+
+export const buildTradeMarkersFromTransactions = ({
+  dates,
+  fundData,
+  transactions,
+  holdingShares,
+}: BuildTradeMarkersFromTransactionsInput): MarkPointDatum[] => {
+  const points: MarkPointDatum[] = [];
+  const sortedTransactions = [...(transactions || [])].sort(compareTransactions);
+  const sellTransactions = sortedTransactions.filter(
+    (tx) => tx.type === 'sell' || tx.type === 'transferOut',
+  );
+  const buyTransactions = sortedTransactions.filter(
+    (tx) => tx.type === 'buy' || tx.type === 'transferIn',
+  );
+
+  let liquidationDate: string | null = null;
+  if (holdingShares === 0 && buyTransactions.length === 0 && sellTransactions.length > 0) {
+    let runningShares = holdingShares + sellTransactions.reduce((sum, tx) => {
+      if (tx.type === 'transferOut') {
+        return sum + (tx.outShares ?? tx.amount);
+      }
+      return sum + tx.amount;
+    }, 0);
+
+    for (const tx of sellTransactions) {
+      const outAmount = tx.type === 'transferOut' ? (tx.outShares ?? tx.amount) : tx.amount;
+      runningShares -= outAmount;
+      if (runningShares <= 0) {
+        liquidationDate = tx.date;
+        break;
+      }
+    }
+
+    if (liquidationDate && !dates.includes(liquidationDate)) {
+      liquidationDate = null;
+    }
+  }
+
+  sortedTransactions.forEach((tx) => {
+    const idx = dates.indexOf(tx.date);
+    if (idx === -1) return;
+
+    const isOutTransaction = tx.type === 'sell' || tx.type === 'transferOut';
+    if (isOutTransaction && liquidationDate && liquidationDate === tx.date) {
+      points.push({
+        name: 'liquidation',
+        coord: [tx.date, fundData[idx] ?? null],
+        itemStyle: { color: TRADE_MARKER_COLORS.liquidation },
+        ...MARKER_DEFAULTS,
+      });
+      return;
+    }
+
+    if (isOutTransaction) {
+      points.push({
+        name: 'sell',
+        coord: [tx.date, fundData[idx] ?? null],
+        itemStyle: { color: TRADE_MARKER_COLORS.sell },
+        ...MARKER_DEFAULTS,
+      });
+      return;
+    }
+
+    points.push({
+      name: 'buy',
+      coord: [tx.date, fundData[idx] ?? null],
+      itemStyle: { color: TRADE_MARKER_COLORS.buy },
+      ...MARKER_DEFAULTS,
+    });
+  });
+
+  return points;
 };
 
 export const buildTradeMarkers = ({
@@ -113,50 +197,14 @@ export const buildTradeMarkers = ({
     }
   }
 
-  const transactions = pendingTransactions || [];
-  const sellTxs = transactions.filter((tx) => tx.type === 'sell' || tx.type === 'transferOut');
-  const buyTxs = transactions.filter((tx) => tx.type === 'buy' || tx.type === 'transferIn');
-
-  let liquidationDate: string | null = null;
-  if (holdingShares === 0 && buyTxs.length === 0 && sellTxs.length > 0) {
-    const sortedSells = [...sellTxs].sort(compareTransactions);
-    let runningShares = holdingShares + sortedSells.reduce((sum, tx) => sum + tx.amount, 0);
-
-    for (const tx of sortedSells) {
-      const outAmount = tx.type === 'transferOut' ? (tx.outShares ?? tx.amount) : tx.amount;
-      runningShares -= outAmount;
-      if (runningShares <= 0) {
-        liquidationDate = tx.date;
-        break;
-      }
-    }
-
-    if (liquidationDate && !dates.includes(liquidationDate)) {
-      liquidationDate = null;
-    }
-  }
-
-  sellTxs.forEach((tx) => {
-    const idx = dates.indexOf(tx.date);
-    if (idx === -1) return;
-
-    if (liquidationDate && liquidationDate === tx.date) {
-      points.push({
-        name: 'liquidation',
-        coord: [tx.date, fundData[idx] ?? null],
-        itemStyle: { color: TRADE_MARKER_COLORS.liquidation },
-        ...MARKER_DEFAULTS,
-      });
-      return;
-    }
-
-    points.push({
-      name: 'sell',
-      coord: [tx.date, fundData[idx] ?? null],
-      itemStyle: { color: TRADE_MARKER_COLORS.sell },
-      ...MARKER_DEFAULTS,
-    });
-  });
+  points.push(
+    ...buildTradeMarkersFromTransactions({
+      dates,
+      fundData,
+      transactions: pendingTransactions,
+      holdingShares,
+    }),
+  );
 
   return points;
 };

--- a/services/db.transactionDelete.test.ts
+++ b/services/db.transactionDelete.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Fund, PendingTransaction } from '../types';
+import { db, deletePendingTransaction } from './db';
+
+const buildTx = (overrides?: Partial<PendingTransaction>): PendingTransaction => ({
+  id: 'tx-1',
+  type: 'buy',
+  date: '2026-03-20',
+  time: 'before15',
+  amount: 100,
+  settlementDate: '2026-03-21',
+  settled: false,
+  ...overrides,
+});
+
+const buildFund = (id: number, txs: PendingTransaction[]): Fund => ({
+  id,
+  code: `00000${id}`,
+  name: `基金${id}`,
+  platform: '天天基金',
+  holdingShares: 100,
+  costPrice: 1,
+  currentNav: 1,
+  lastUpdate: '2026-03-20',
+  dayChangePct: 0,
+  dayChangeVal: 0,
+  pendingTransactions: txs,
+});
+
+describe('deletePendingTransaction', () => {
+  const mockTransaction = () =>
+    vi.spyOn(db, 'transaction').mockImplementation((...args: unknown[]) => {
+      const scope = args[args.length - 1] as () => unknown;
+      return Promise.resolve(scope()) as never;
+    });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('deletes a single pending transaction within one fund', async () => {
+    const targetTx = buildTx({ id: 'single-delete' });
+    const keepTx = buildTx({ id: 'keep-me' });
+    const fund = buildFund(1, [targetTx, keepTx]);
+
+    mockTransaction();
+    vi.spyOn(db.funds, 'get').mockResolvedValue(fund);
+    const updateSpy = vi.spyOn(db.funds, 'update').mockResolvedValue(1);
+
+    const result = await deletePendingTransaction({
+      fundId: 1,
+      txId: 'single-delete',
+      type: 'buy',
+    });
+
+    expect(result).toEqual({
+      deletedCount: 1,
+      affectedFundIds: [1],
+      linkedDelete: false,
+    });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        pendingTransactions: [expect.objectContaining({ id: 'keep-me' })],
+      }),
+    );
+  });
+
+  it('deletes linked transfer transactions across funds atomically', async () => {
+    const transferId = 'transfer-1';
+    const sourceTx = buildTx({ id: 'tx-out', type: 'transferOut', transferId });
+    const targetTx = buildTx({ id: 'tx-in', type: 'transferIn', transferId });
+
+    const sourceFund = buildFund(1, [sourceTx]);
+    const targetFund = buildFund(2, [targetTx]);
+
+    vi.spyOn(db.funds, 'toArray').mockResolvedValue([sourceFund, targetFund]);
+    const updateSpy = vi.spyOn(db.funds, 'update').mockResolvedValue(1);
+    const transactionSpy = mockTransaction();
+
+    const result = await deletePendingTransaction({
+      fundId: 1,
+      txId: 'tx-out',
+      transferId,
+      type: 'transferOut',
+    });
+
+    expect(result).toEqual({
+      deletedCount: 2,
+      affectedFundIds: [1, 2],
+      linkedDelete: true,
+    });
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledTimes(2);
+    expect(updateSpy).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ pendingTransactions: [] }),
+    );
+    expect(updateSpy).toHaveBeenCalledWith(
+      2,
+      expect.objectContaining({ pendingTransactions: [] }),
+    );
+  });
+
+  it('rejects linked delete when matched transfer records exceed guardrail', async () => {
+    const transferId = 'transfer-over-limit';
+    const txA = buildTx({ id: 'tx-a', type: 'transferOut', transferId });
+    const txB = buildTx({ id: 'tx-b', type: 'transferIn', transferId });
+    const txC = buildTx({ id: 'tx-c', type: 'transferIn', transferId });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    vi.spyOn(db.funds, 'toArray').mockResolvedValue([
+      buildFund(1, [txA]),
+      buildFund(2, [txB]),
+      buildFund(3, [txC]),
+    ]);
+    const updateSpy = vi.spyOn(db.funds, 'update').mockResolvedValue(1);
+
+    const result = await deletePendingTransaction({
+      fundId: 1,
+      txId: 'tx-a',
+      transferId,
+      type: 'transferOut',
+    });
+
+    expect(result).toMatchObject({
+      code: 'LINKED_DELETE_OVER_LIMIT',
+      userMessageKey: 'common.linkedDeleteOverLimit',
+      linkedDelete: true,
+      deletedCount: 0,
+      affectedFundIds: [],
+      logFields: {
+        transferId,
+        matchedCount: 3,
+        fundId: 1,
+      },
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[deletePendingTransaction] linked delete matched over limit',
+      expect.objectContaining({
+        transferId,
+        matchedCount: 3,
+        fundId: 1,
+      }),
+    );
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger cross-fund linked delete when anchor txId does not match fund transaction', async () => {
+    const transferId = 'transfer-anchor-check';
+    const sourceTx = buildTx({ id: 'tx-out', type: 'transferOut', transferId });
+    const targetTx = buildTx({ id: 'tx-in', type: 'transferIn', transferId });
+
+    vi.spyOn(db.funds, 'toArray').mockResolvedValue([buildFund(1, [sourceTx]), buildFund(2, [targetTx])]);
+    const updateSpy = vi.spyOn(db.funds, 'update').mockResolvedValue(1);
+
+    const result = await deletePendingTransaction({
+      fundId: 1,
+      txId: 'non-exist-tx',
+      transferId,
+      type: 'transferOut',
+    });
+
+    expect(result).toEqual({
+      deletedCount: 0,
+      affectedFundIds: [],
+      linkedDelete: true,
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger linked delete for buy/sell even when transferId exists', async () => {
+    const tx = buildTx({ id: 'tx-buy-with-transfer', type: 'buy', transferId: 'fake-transfer-id' });
+    const fund = buildFund(7, [tx]);
+
+    mockTransaction();
+    vi.spyOn(db.funds, 'get').mockResolvedValue(fund);
+    const updateSpy = vi.spyOn(db.funds, 'update').mockResolvedValue(1);
+
+    const result = await deletePendingTransaction({
+      fundId: 7,
+      txId: 'tx-buy-with-transfer',
+      transferId: 'fake-transfer-id',
+      type: 'buy',
+    });
+
+    expect(result).toEqual({
+      deletedCount: 1,
+      affectedFundIds: [7],
+      linkedDelete: false,
+    });
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/db.ts
+++ b/services/db.ts
@@ -1,5 +1,12 @@
 import Dexie, { type Table } from 'dexie';
-import type { Fund, Account, AssetSummary, WatchlistItem, EquityHolding } from '../types';
+import type {
+  Fund,
+  Account,
+  AssetSummary,
+  WatchlistItem,
+  EquityHolding,
+  PendingTransaction,
+} from '../types';
 import {
   fetchFundCommonData,
   fetchEastMoneyLatestNav,
@@ -246,6 +253,139 @@ const getUnsettledOutShares = (fund: Fund) => {
     if (tx.type === 'transferOut') return sum + (tx.outShares ?? tx.amount ?? 0);
     return sum;
   }, 0);
+};
+
+export type DeletePendingTransactionParams = {
+  fundId: number;
+  txId: string;
+  transferId?: string;
+  type: PendingTransaction['type'];
+};
+
+export type DeletePendingTransactionSuccess = {
+  deletedCount: number;
+  affectedFundIds: number[];
+  linkedDelete: boolean;
+};
+
+export type DeletePendingTransactionError = DeletePendingTransactionSuccess & {
+  code: 'LINKED_DELETE_OVER_LIMIT';
+  userMessageKey: 'common.linkedDeleteOverLimit';
+  logFields: {
+    transferId?: string;
+    matchedCount: number;
+    fundId: number;
+  };
+};
+
+export type DeletePendingTransactionResult =
+  | DeletePendingTransactionSuccess
+  | DeletePendingTransactionError;
+
+const TRANSFER_DELETE_TYPES: PendingTransaction['type'][] = ['transferOut', 'transferIn'];
+
+export const deletePendingTransaction = async (
+  params: DeletePendingTransactionParams,
+): Promise<DeletePendingTransactionResult> => {
+  const { fundId, txId, transferId, type } = params;
+  const isLinkedDelete =
+    Boolean(transferId) &&
+    (type === TRANSFER_DELETE_TYPES[0] || type === TRANSFER_DELETE_TYPES[1]);
+
+  if (!isLinkedDelete) {
+    let deletedCount = 0;
+    const affectedFundIds = new Set<number>();
+
+    await db.transaction('rw', db.funds, async () => {
+      const fund = await db.funds.get(fundId);
+      if (!fund) return;
+
+      const originalTxs = fund.pendingTransactions || [];
+      const nextTxs = originalTxs.filter((tx) => tx.id !== txId);
+      if (nextTxs.length === originalTxs.length) return;
+
+      deletedCount = originalTxs.length - nextTxs.length;
+      affectedFundIds.add(fundId);
+      await db.funds.update(fundId, { pendingTransactions: nextTxs });
+    });
+
+    return {
+      deletedCount,
+      affectedFundIds: Array.from(affectedFundIds).sort((a, b) => a - b),
+      linkedDelete: false,
+    };
+  }
+
+  const allFunds = await db.funds.toArray();
+  const anchorFund = allFunds.find((fund) => fund.id === fundId);
+  const anchorTx = (anchorFund?.pendingTransactions || []).find((tx) => tx.id === txId);
+  const isValidAnchor =
+    Boolean(anchorTx) && anchorTx?.transferId === transferId && anchorTx?.type === type;
+
+  if (!isValidAnchor) {
+    return {
+      deletedCount: 0,
+      affectedFundIds: [],
+      linkedDelete: true,
+    };
+  }
+
+  const matchedTxByFund = new Map<number, string[]>();
+
+  allFunds.forEach((fund) => {
+    if (!fund.id) return;
+
+    (fund.pendingTransactions || []).forEach((tx) => {
+      if (tx.transferId !== transferId) return;
+      if (tx.type !== 'transferOut' && tx.type !== 'transferIn') return;
+
+      const existing = matchedTxByFund.get(fund.id) || [];
+      matchedTxByFund.set(fund.id, [...existing, tx.id]);
+    });
+  });
+
+  const matchedCount = Array.from(matchedTxByFund.values()).reduce((sum, txIds) => sum + txIds.length, 0);
+  if (matchedCount > 2) {
+    const logFields = {
+      transferId,
+      matchedCount,
+      fundId,
+    };
+    console.warn('[deletePendingTransaction] linked delete matched over limit', logFields);
+
+    return {
+      code: 'LINKED_DELETE_OVER_LIMIT',
+      userMessageKey: 'common.linkedDeleteOverLimit',
+      logFields,
+      deletedCount: 0,
+      affectedFundIds: [],
+      linkedDelete: true,
+    };
+  }
+
+  let deletedCount = 0;
+  const affectedFundIds = new Set<number>();
+
+  await db.transaction('rw', db.funds, async () => {
+    for (const [linkedFundId, txIds] of matchedTxByFund.entries()) {
+      const fund = allFunds.find((item) => item.id === linkedFundId);
+      if (!fund) continue;
+
+      const originalTxs = fund.pendingTransactions || [];
+      const nextTxs = originalTxs.filter((tx) => !txIds.includes(tx.id));
+      if (nextTxs.length === originalTxs.length) continue;
+
+      deletedCount += originalTxs.length - nextTxs.length;
+      affectedFundIds.add(linkedFundId);
+      await db.funds.update(linkedFundId, { pendingTransactions: nextTxs });
+    }
+  });
+
+  return {
+    deletedCount,
+    affectedFundIds: Array.from(affectedFundIds).sort((a, b) => a - b),
+    linkedDelete: true,
+  };
 };
 
 /**

--- a/services/i18n.tsx
+++ b/services/i18n.tsx
@@ -221,6 +221,12 @@ const dictionary = {
       transactionHistory: 'Transaction History',
       noHistory: 'No transaction history',
       cancelConfirm: 'Are you sure you want to cancel this pending transaction?',
+      deleteConfirm: 'Are you sure you want to delete this settled transaction?',
+      linkedDeleteConfirm:
+        'Deleting this rebalance transaction will also delete its linked record. Continue?',
+      linkedDeleteOverLimit:
+        'Linked records exceeded safe limit. Deletion was blocked. Please retry later.',
+      deleteFailed: 'Delete failed. Please try again later.',
       undo: 'Undo',
       all: 'All',
       defaultAccount: 'Default',
@@ -473,6 +479,10 @@ const dictionary = {
       transactionHistory: '交易记录',
       noHistory: '暂无交易记录',
       cancelConfirm: '确定要撤销这笔在途交易吗？',
+      deleteConfirm: '确定要删除这条已确认交易记录吗？',
+      linkedDeleteConfirm: '删除该调仓记录将同时删除关联记录，是否继续？',
+      linkedDeleteOverLimit: '关联记录数量异常，已阻止删除，请稍后重试。',
+      deleteFailed: '删除失败，请稍后重试',
       undo: '撤销',
       all: '全部',
       defaultAccount: '默认',


### PR DESCRIPTION
## Summary
- add delete flow for settled fund transactions from transaction history
- update db transaction logic and chart marker handling after deletion
- add regression tests for delete flow, db behavior and chart marker updates

## Test Plan
- npm run test -- components/TransactionHistoryModal.delete.test.tsx services/db.transactionDelete.test.ts components/fundDetailChartUtils.marker.test.ts