### PR TITLE
fix(modal): centralize dismiss behavior for modal animations

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -73,6 +73,20 @@ const AppContent: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      const activeOverlayId = getActiveOverlayId();
+      if (!activeOverlayId) return;
+      closeTopOverlay({ source: 'programmatic', targetX: window.innerWidth });
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
     let startX = 0;
     let startY = 0;
     let edge: 'left' | 'right' | null = null;

--- a/components/AccountManagerModal.tsx
+++ b/components/AccountManagerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '../services/db';
 import { useTranslation } from '../services/i18n';
@@ -13,6 +13,17 @@ interface AccountManagerModalProps {
 export const AccountManagerModal: React.FC<AccountManagerModalProps> = ({ isOpen, onClose }) => {
   const accounts = useLiveQuery(() => db.accounts.toArray());
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
 
   // Add State
   const [newAccountName, setNewAccountName] = useState('');
@@ -74,8 +85,14 @@ export const AccountManagerModal: React.FC<AccountManagerModalProps> = ({ isOpen
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
-      <div className="bg-white dark:bg-card-dark rounded-lg w-full max-w-sm overflow-hidden shadow-xl animate-in fade-in zoom-in duration-200 flex flex-col max-h-[90vh]">
+    <div
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-card-dark rounded-lg w-full max-w-sm overflow-hidden shadow-xl animate-in fade-in zoom-in duration-200 flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="p-4 border-b border-gray-100 dark:border-border-dark flex justify-between items-center bg-gray-50 dark:bg-white/5 shrink-0">
           <h2 className="font-bold text-gray-800 dark:text-gray-100">
             {t('common.manageAccounts')}

--- a/components/AddFundModal.tsx
+++ b/components/AddFundModal.tsx
@@ -145,7 +145,7 @@ export const AddFundModal: React.FC<AddFundModalProps> = ({
 
   const requestClose = useCallback(
     (payload?: { source?: 'edge-swipe' | 'programmatic'; targetX?: number }) => {
-      if (payload?.source === 'edge-swipe' && payload.targetX !== undefined) {
+      if (payload?.targetX !== undefined) {
         setCloseTargetX(payload.targetX);
         return;
       }
@@ -349,10 +349,14 @@ export const AddFundModal: React.FC<AddFundModalProps> = ({
   const info = displayInfo();
 
   return (
-    <div className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
+    <div
+      className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={() => requestClose({ source: 'programmatic', targetX: window.innerWidth })}
+    >
       <div
         className="bg-white dark:bg-card-dark rounded-xl w-full max-w-md overflow-hidden shadow-2xl flex flex-col max-h-[90vh]"
         style={{ transform: `translateX(${transformX})`, transition }}
+        onClick={(e) => e.stopPropagation()}
         onTransitionEnd={() => {
           if (closeTargetX !== null) {
             setCloseTargetX(null);

--- a/components/AddWatchlistModal.tsx
+++ b/components/AddWatchlistModal.tsx
@@ -108,7 +108,7 @@ export const AddWatchlistModal: React.FC<AddWatchlistModalProps> = ({
 
   const requestClose = useCallback(
     (payload?: { source?: 'edge-swipe' | 'programmatic'; targetX?: number }) => {
-      if (payload?.source === 'edge-swipe' && payload.targetX !== undefined) {
+      if (payload?.targetX !== undefined) {
         setCloseTargetX(payload.targetX);
         return;
       }
@@ -193,36 +193,37 @@ export const AddWatchlistModal: React.FC<AddWatchlistModalProps> = ({
     }
   };
 
-  if (!isOpen) return null;
-
   return (
     <AnimatePresence>
-      <motion.div
-        className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-      >
-        <div
-          style={{ transform: `translateX(${transformX})`, transition }}
-          onTransitionEnd={() => {
-            if (closeTargetX !== null) {
-              setCloseTargetX(null);
-              resetDragState(setDragState);
-              handleClose();
-              return;
-            }
-            if (snapX !== null) {
-              resetDragState(setDragState);
-            }
-          }}
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+          onClick={() => requestClose({ source: 'programmatic', targetX: window.innerWidth })}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
         >
-          <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 20 }}
-            className="bg-white dark:bg-card-dark rounded-xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[90vh]"
+          <div
+            style={{ transform: `translateX(${transformX})`, transition }}
+            onTransitionEnd={() => {
+              if (closeTargetX !== null) {
+                setCloseTargetX(null);
+                resetDragState(setDragState);
+                handleClose();
+                return;
+              }
+              if (snapX !== null) {
+                resetDragState(setDragState);
+              }
+            }}
           >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 20 }}
+              className="bg-white dark:bg-card-dark rounded-xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[90vh]"
+              onClick={(e) => e.stopPropagation()}
+            >
             {/* Header */}
             <div className="flex justify-between items-center p-4 border-b border-gray-100 dark:border-border-dark bg-gray-50/50 dark:bg-white/5 shrink-0">
               <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100">
@@ -401,9 +402,10 @@ export const AddWatchlistModal: React.FC<AddWatchlistModalProps> = ({
                 {t('common.save')}
               </button>
             </div>
-          </motion.div>
-        </div>
-      </motion.div>
+            </motion.div>
+          </div>
+        </motion.div>
+      )}
     </AnimatePresence>
   );
 };

--- a/components/AdjustPositionModal.tsx
+++ b/components/AdjustPositionModal.tsx
@@ -61,7 +61,7 @@ export const AdjustPositionModal: React.FC<AdjustPositionModalProps> = ({
 
   const requestClose = useCallback(
     (payload?: { source?: 'edge-swipe' | 'programmatic'; targetX?: number }) => {
-      if (payload?.source === 'edge-swipe' && payload.targetX !== undefined) {
+      if (payload?.targetX !== undefined) {
         setCloseTargetX(payload.targetX);
         return;
       }
@@ -136,10 +136,14 @@ export const AdjustPositionModal: React.FC<AdjustPositionModalProps> = ({
   const pendingCount = (fund.pendingTransactions || []).filter((tx) => !tx.settled).length;
 
   return (
-    <div className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
+    <div
+      className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={() => requestClose({ source: 'programmatic', targetX: window.innerWidth })}
+    >
       <div
         className="bg-white dark:bg-card-dark rounded-xl w-full max-w-md overflow-hidden shadow-2xl flex flex-col max-h-[90vh]"
         style={{ transform: `translateX(${transformX})`, transition }}
+        onClick={(e) => e.stopPropagation()}
         onTransitionEnd={() => {
           if (closeTargetX !== null) {
             setCloseTargetX(null);

--- a/components/AiHoldingsAnalysisModal.tsx
+++ b/components/AiHoldingsAnalysisModal.tsx
@@ -307,7 +307,16 @@ export const AiHoldingsAnalysisModal: React.FC<AiHoldingsAnalysisModalProps> = (
     }
   };
 
-  if (!isOpen) return null;
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [handleClose, isOpen]);
 
   const summary = holdingsSnapshot || {
     asOf: getLocalDateString(),

--- a/components/FundDetail.tsx
+++ b/components/FundDetail.tsx
@@ -208,7 +208,7 @@ export const FundDetail: React.FC<FundDetailProps> = ({
 
   const requestClose = useCallback(
     (payload?: { source?: 'edge-swipe' | 'programmatic'; targetX?: number }) => {
-      if (payload?.source === 'edge-swipe' && payload.targetX !== undefined) {
+      if (payload?.targetX !== undefined) {
         setCloseTargetX(payload.targetX);
         setIsEdgeClosing(true);
         return;

--- a/components/GistSyncChooserCard.tsx
+++ b/components/GistSyncChooserCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { AnimatedSwitcher } from './transitions/AnimatedSwitcher';
 
@@ -62,6 +62,17 @@ export const GistSyncChooserCard: React.FC<GistSyncChooserCardProps> = ({
   const descriptionLen = description.length;
   const isDownloadConfirmDisabled = !selectedGistId;
   const isOverwriteConfirmDisabled = uploadMode === 'overwrite' && !selectedGistId;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
 
   const title = cardMode === 'download' ? '选择要下载的 Gist' : '选择上传方式';
 

--- a/components/RebalanceModal.tsx
+++ b/components/RebalanceModal.tsx
@@ -84,6 +84,17 @@ export const RebalanceModal: React.FC<RebalanceModalProps> = ({
 
   useEffect(() => {
     if (!isOpen) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
     setError('');
     setOutSharesInput('');
     setSellFeeRate(0.005);
@@ -306,8 +317,14 @@ export const RebalanceModal: React.FC<RebalanceModalProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
-      <div className="bg-white dark:bg-card-dark rounded-xl w-full max-w-md overflow-hidden shadow-2xl flex flex-col max-h-[90vh]">
+    <div
+      className="fixed inset-0 z-[60] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-card-dark rounded-xl w-full max-w-md overflow-hidden shadow-2xl flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="p-4 border-b border-gray-100 dark:border-border-dark flex justify-between items-center bg-gray-50 dark:bg-white/5">
           <h3 className="font-bold text-gray-800 dark:text-gray-100">
             {t('common.rebalanceTitle')}

--- a/components/ScannerModal.tsx
+++ b/components/ScannerModal.tsx
@@ -76,7 +76,7 @@ export const ScannerModal: React.FC<ScannerModalProps> = ({ isOpen, onClose }) =
 
   const requestClose = useCallback(
     (payload?: { source?: 'edge-swipe' | 'programmatic'; targetX?: number }) => {
-      if (payload?.source === 'edge-swipe' && payload.targetX !== undefined) {
+      if (payload?.targetX !== undefined) {
         setCloseTargetX(payload.targetX);
         return;
       }

--- a/components/TransactionHistoryModal.tsx
+++ b/components/TransactionHistoryModal.tsx
@@ -34,7 +34,7 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
 
   const requestClose = useCallback(
     (payload?: { source?: 'edge-swipe' | 'programmatic'; targetX?: number }) => {
-      if (payload?.source === 'edge-swipe' && payload.targetX !== undefined) {
+      if (payload?.targetX !== undefined) {
         setCloseTargetX(payload.targetX);
         return;
       }
@@ -94,10 +94,14 @@ export const TransactionHistoryModal: React.FC<TransactionHistoryModalProps> = (
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm sm:p-4 opacity-100 transition-opacity">
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm sm:p-4 opacity-100 transition-opacity"
+      onClick={() => requestClose({ source: 'programmatic', targetX: window.innerWidth })}
+    >
       <div
         className="bg-white dark:bg-card-dark w-full sm:w-[480px] sm:rounded-2xl rounded-t-2xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh] transition-transform translate-y-0 relative"
         style={{ transform: `translateX(${transformX})`, transition }}
+        onClick={(e) => e.stopPropagation()}
         onTransitionEnd={() => {
           if (closeTargetX !== null) {
             setCloseTargetX(null);


### PR DESCRIPTION
## Summary
- add shared modal close/dismiss handling path for open modals
- align close behavior across account, watchlist, rebalance, scanner and history dialogs
- reduce inconsistent animation interruption during modal dismissal

## Test Plan
- npm run build