### PR TITLE
fix: align watchlist layout and normalize fund names

### DIFF
--- a/components/AddWatchlistModal.tsx
+++ b/components/AddWatchlistModal.tsx
@@ -4,6 +4,7 @@ import { Icons } from './Icon';
 import { useTranslation } from '../services/i18n';
 import type { WatchlistItem, MorningstarFund } from '../types';
 import { searchFunds, fetchHistoricalFundNav, fetchHistoricalIndexPrice } from '../services/api';
+import { pickWatchlistNameFromMorningstar } from '../services/watchlistName';
 import { motion, AnimatePresence } from 'framer-motion';
 import { resetDragState, useEdgeSwipe } from '../services/useEdgeSwipe';
 import { useOverlayRegistration } from '../services/overlayRegistration';
@@ -148,7 +149,7 @@ export const AddWatchlistModal: React.FC<AddWatchlistModalProps> = ({
 
   const handleSelectFund = (fund: MorningstarFund) => {
     setCode(fund.symbol);
-    setName(fund.fundName);
+    setName(pickWatchlistNameFromMorningstar(fund));
     setSearchQuery(''); // Close dropdown
   };
 
@@ -224,184 +225,184 @@ export const AddWatchlistModal: React.FC<AddWatchlistModalProps> = ({
               className="bg-white dark:bg-card-dark rounded-xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[90vh]"
               onClick={(e) => e.stopPropagation()}
             >
-            {/* Header */}
-            <div className="flex justify-between items-center p-4 border-b border-gray-100 dark:border-border-dark bg-gray-50/50 dark:bg-white/5 shrink-0">
-              <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100">
-                {editItem ? t('common.edit') : t('common.addWatchlist')}
-              </h2>
-              <button
-                onClick={handleClose}
-                className="p-1 hover:bg-gray-200 dark:hover:bg-white/10 rounded-full transition-colors text-gray-500"
-              >
-                <Icons.Plus size={20} className="transform rotate-45" />
-              </button>
-            </div>
-
-            {/* Type Selector (Only when adding) */}
-            <div className="p-4 flex flex-col gap-4 overflow-y-auto flex-1 relative z-20">
-              {!editItem && (
-                <div className="flex bg-gray-100 dark:bg-white/10 p-1 rounded-lg">
-                  <button
-                    className={`flex-1 py-1.5 text-sm font-medium rounded-md transition-colors ${type === 'fund' ? 'bg-white dark:bg-card-dark text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}`}
-                    onClick={() => setType('fund')}
-                  >
-                    {t('common.fund')}
-                  </button>
-                  <button
-                    className={`flex-1 py-1.5 text-sm font-medium rounded-md transition-colors ${type === 'index' ? 'bg-white dark:bg-card-dark text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}`}
-                    onClick={() => setType('index')}
-                  >
-                    {t('common.indexOrSector')}
-                  </button>
-                </div>
-              )}
-
-              {/* Fund Search */}
-              {type === 'fund' && !editItem && (
-                <div className="relative z-20">
-                  <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
-                    {t('common.searchFund')}
-                  </label>
-                  <div className="relative">
-                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <Icons.Settings
-                        size={16}
-                        className={`text-gray-400 ${isSearching ? 'animate-spin' : ''}`}
-                      />
-                    </div>
-                    <input
-                      type="text"
-                      className="w-full pl-10 pr-4 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
-                      placeholder={t('common.searchPlaceholder')}
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                    />
-                  </div>
-
-                  {/* Dropdown */}
-                  {searchResults.length > 0 && searchQuery && (
-                    <div className="absolute left-0 right-0 mt-1 bg-white dark:bg-card-dark border border-gray-200 dark:border-border-dark rounded-lg shadow-xl max-h-60 overflow-y-auto z-50">
-                      {searchResults.map((fund) => (
-                        <div
-                          key={fund.fundClassId}
-                          className="px-4 py-3 hover:bg-gray-50 dark:hover:bg-white/5 cursor-pointer border-b border-gray-50 dark:border-border-dark last:border-0"
-                          onClick={() => handleSelectFund(fund)}
-                        >
-                          <div className="flex justify-between items-center mb-1">
-                            <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate pr-2">
-                              {fund.fundName}
-                            </span>
-                            <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-white/10 text-gray-600 dark:text-gray-400">
-                              {fund.symbol}
-                            </span>
-                          </div>
-                          <div className="text-xs text-gray-500 dark:text-gray-400 flex gap-2">
-                            <span>{fund.fundType}</span>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* Code & Name (Manual Entry / Selected) */}
-              <div className="grid grid-cols-2 gap-4 relative z-10">
-                <div>
-                  <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
-                    {t('common.code')}
-                  </label>
-                  <input
-                    type="text"
-                    className="w-full px-3 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
-                    value={code}
-                    onChange={(e) => setCode(e.target.value)}
-                    placeholder={
-                      type === 'index'
-                        ? t('common.indexCodePlaceholder')
-                        : t('common.fundCodePlaceholder')
-                    }
-                  />
-                </div>
-                <div className="col-span-1">
-                  <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
-                    {t('common.fund')}
-                  </label>
-                  <input
-                    type="text"
-                    className="w-full px-3 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder={
-                      type === 'index'
-                        ? t('common.indexNamePlaceholder')
-                        : t('common.fundNamePlaceholder')
-                    }
-                  />
-                </div>
+              {/* Header */}
+              <div className="flex justify-between items-center p-4 border-b border-gray-100 dark:border-border-dark bg-gray-50/50 dark:bg-white/5 shrink-0">
+                <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100">
+                  {editItem ? t('common.edit') : t('common.addWatchlist')}
+                </h2>
+                <button
+                  onClick={handleClose}
+                  className="p-1 hover:bg-gray-200 dark:hover:bg-white/10 rounded-full transition-colors text-gray-500"
+                >
+                  <Icons.Plus size={20} className="transform rotate-45" />
+                </button>
               </div>
 
-              {/* Anchor Details */}
-              <div className="grid grid-cols-2 gap-4 relative z-10">
-                <div>
-                  <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
-                    {t('common.anchorPrice')}
-                  </label>
-                  <div className="relative">
-                    <input
-                      type="text"
-                      className="w-full px-3 py-2 bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none dark:text-gray-300 text-gray-500 cursor-not-allowed"
-                      value={anchorPrice}
-                      readOnly
-                      placeholder={
-                        isFetchingPrice ? t('common.fetching') : t('common.autoFillDate')
-                      }
-                    />
-                    {isFetchingPrice && (
-                      <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                        <Icons.Settings size={16} className="text-gray-400 animate-spin" />
+              {/* Type Selector (Only when adding) */}
+              <div className="p-4 flex flex-col gap-4 overflow-y-auto flex-1 relative z-20">
+                {!editItem && (
+                  <div className="flex bg-gray-100 dark:bg-white/10 p-1 rounded-lg">
+                    <button
+                      className={`flex-1 py-1.5 text-sm font-medium rounded-md transition-colors ${type === 'fund' ? 'bg-white dark:bg-card-dark text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}`}
+                      onClick={() => setType('fund')}
+                    >
+                      {t('common.fund')}
+                    </button>
+                    <button
+                      className={`flex-1 py-1.5 text-sm font-medium rounded-md transition-colors ${type === 'index' ? 'bg-white dark:bg-card-dark text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}`}
+                      onClick={() => setType('index')}
+                    >
+                      {t('common.indexOrSector')}
+                    </button>
+                  </div>
+                )}
+
+                {/* Fund Search */}
+                {type === 'fund' && !editItem && (
+                  <div className="relative z-20">
+                    <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
+                      {t('common.searchFund')}
+                    </label>
+                    <div className="relative">
+                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <Icons.Settings
+                          size={16}
+                          className={`text-gray-400 ${isSearching ? 'animate-spin' : ''}`}
+                        />
+                      </div>
+                      <input
+                        type="text"
+                        className="w-full pl-10 pr-4 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
+                        placeholder={t('common.searchPlaceholder')}
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                      />
+                    </div>
+
+                    {/* Dropdown */}
+                    {searchResults.length > 0 && searchQuery && (
+                      <div className="absolute left-0 right-0 mt-1 bg-white dark:bg-card-dark border border-gray-200 dark:border-border-dark rounded-lg shadow-xl max-h-60 overflow-y-auto z-50">
+                        {searchResults.map((fund) => (
+                          <div
+                            key={fund.fundClassId}
+                            className="px-4 py-3 hover:bg-gray-50 dark:hover:bg-white/5 cursor-pointer border-b border-gray-50 dark:border-border-dark last:border-0"
+                            onClick={() => handleSelectFund(fund)}
+                          >
+                            <div className="flex justify-between items-center mb-1">
+                              <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate pr-2">
+                                {fund.fundName}
+                              </span>
+                              <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-white/10 text-gray-600 dark:text-gray-400">
+                                {fund.symbol}
+                              </span>
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400 flex gap-2">
+                              <span>{fund.fundType}</span>
+                            </div>
+                          </div>
+                        ))}
                       </div>
                     )}
                   </div>
-                  {!anchorPrice && !isFetchingPrice && code && (
-                    <span className="text-[10px] text-red-500 mt-1 block">
-                      {t('common.noDataDate')}
-                    </span>
-                  )}
+                )}
+
+                {/* Code & Name (Manual Entry / Selected) */}
+                <div className="grid grid-cols-2 gap-4 relative z-10">
+                  <div>
+                    <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
+                      {t('common.code')}
+                    </label>
+                    <input
+                      type="text"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
+                      value={code}
+                      onChange={(e) => setCode(e.target.value)}
+                      placeholder={
+                        type === 'index'
+                          ? t('common.indexCodePlaceholder')
+                          : t('common.fundCodePlaceholder')
+                      }
+                    />
+                  </div>
+                  <div className="col-span-1">
+                    <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
+                      {t('common.fund')}
+                    </label>
+                    <input
+                      type="text"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      placeholder={
+                        type === 'index'
+                          ? t('common.indexNamePlaceholder')
+                          : t('common.fundNamePlaceholder')
+                      }
+                    />
+                  </div>
                 </div>
-                <div>
-                  <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
-                    {t('common.anchorDate')}
-                  </label>
-                  <input
-                    type="date"
-                    className="w-full px-3 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
-                    value={anchorDate}
-                    onChange={(e) => setAnchorDate(e.target.value)}
-                  />
+
+                {/* Anchor Details */}
+                <div className="grid grid-cols-2 gap-4 relative z-10">
+                  <div>
+                    <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
+                      {t('common.anchorPrice')}
+                    </label>
+                    <div className="relative">
+                      <input
+                        type="text"
+                        className="w-full px-3 py-2 bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none dark:text-gray-300 text-gray-500 cursor-not-allowed"
+                        value={anchorPrice}
+                        readOnly
+                        placeholder={
+                          isFetchingPrice ? t('common.fetching') : t('common.autoFillDate')
+                        }
+                      />
+                      {isFetchingPrice && (
+                        <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                          <Icons.Settings size={16} className="text-gray-400 animate-spin" />
+                        </div>
+                      )}
+                    </div>
+                    {!anchorPrice && !isFetchingPrice && code && (
+                      <span className="text-[10px] text-red-500 mt-1 block">
+                        {t('common.noDataDate')}
+                      </span>
+                    )}
+                  </div>
+                  <div>
+                    <label className="block text-xs font-bold text-gray-500 dark:text-gray-400 mb-1">
+                      {t('common.anchorDate')}
+                    </label>
+                    <input
+                      type="date"
+                      className="w-full px-3 py-2 bg-gray-50 dark:bg-black/20 border border-gray-200 dark:border-border-dark rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-white"
+                      value={anchorDate}
+                      onChange={(e) => setAnchorDate(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="text-xs text-gray-400 mt-2 bg-blue-50 dark:bg-blue-900/20 p-2 rounded-lg text-blue-600 dark:text-blue-400">
+                  {type === 'index' ? t('common.indexTip') : t('common.fundTip')}
                 </div>
               </div>
 
-              <div className="text-xs text-gray-400 mt-2 bg-blue-50 dark:bg-blue-900/20 p-2 rounded-lg text-blue-600 dark:text-blue-400">
-                {type === 'index' ? t('common.indexTip') : t('common.fundTip')}
+              {/* Footer */}
+              <div className="p-4 border-t border-gray-100 dark:border-border-dark bg-gray-50/50 dark:bg-white/5 flex justify-end gap-3 z-10 relative shrink-0">
+                <button
+                  onClick={handleClose}
+                  className="px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-white/10 rounded-lg transition-colors"
+                >
+                  {t('common.cancel')}
+                </button>
+                <button
+                  onClick={handleSave}
+                  className="px-6 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"
+                >
+                  {t('common.save')}
+                </button>
               </div>
-            </div>
-
-            {/* Footer */}
-            <div className="p-4 border-t border-gray-100 dark:border-border-dark bg-gray-50/50 dark:bg-white/5 flex justify-end gap-3 z-10 relative shrink-0">
-              <button
-                onClick={handleClose}
-                className="px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-white/10 rounded-lg transition-colors"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={handleSave}
-                className="px-6 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"
-              >
-                {t('common.save')}
-              </button>
-            </div>
             </motion.div>
           </div>
         </motion.div>

--- a/components/Watchlist.tsx
+++ b/components/Watchlist.tsx
@@ -362,7 +362,7 @@ export const Watchlist: React.FC = () => {
                     />
                   )}
                 </button>
-                <div />
+                <div>现价</div>
                 <button
                   onClick={() => handleSort('anchorGain')}
                   className="flex items-center justify-end gap-1 transition-colors hover:text-slate-700 dark:hover:text-gray-200"
@@ -441,88 +441,89 @@ export const Watchlist: React.FC = () => {
                     onTouchEnd={handleTouchEnd}
                     onTouchCancel={handleTouchEnd}
                     onClick={() => handleRowClick(item)}
-                    className={`group flex items-start justify-between gap-2 cursor-pointer select-none border-b border-[var(--app-shell-line)]/80 px-4 py-4 transition-colors dark:border-border-dark md:flex-row md:border-none md:hover:bg-[var(--app-shell-panel-strong)]/72 dark:md:hover:bg-white/5 ${contextMenu?.itemId === item.id ? 'bg-[var(--app-shell-panel-strong)] dark:bg-white/10' : ''}`}
+                    className={`group relative cursor-pointer select-none border-b border-[var(--app-shell-line)]/80 px-4 py-3 transition-colors last:border-b-0 active:bg-[var(--app-shell-panel-strong)] dark:border-border-dark dark:active:bg-white/5 md:px-5 md:py-3.5 md:hover:bg-[var(--app-shell-panel-strong)]/72 dark:md:hover:bg-white/5 ${
+                      contextMenu?.itemId === item.id
+                        ? 'bg-[var(--app-shell-panel-strong)] dark:bg-white/10'
+                        : ''
+                    }`}
                   >
-                    <div className="min-w-0 flex-1 md:flex-[1.5] md:self-center">
-                      <div className="hidden items-center gap-2 md:flex">
-                        <span className="rounded-full border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/92 px-2 py-1 text-[10px] font-semibold tracking-[0.14em] whitespace-nowrap shrink-0 text-slate-700 dark:border-blue-400/20 dark:bg-blue-500/10 dark:text-blue-200">
-                          {item.code}
-                        </span>
-                        <span
-                          className={`rounded-full border px-2 py-1 text-[10px] font-semibold tracking-[0.14em] whitespace-nowrap shrink-0 ${
-                            item.type === 'index'
-                              ? 'border-[var(--app-shell-line-strong)] bg-[var(--app-shell-panel-strong)] text-slate-700 dark:border-purple-400/20 dark:bg-purple-500/10 dark:text-purple-300'
-                              : 'border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-gray-400'
-                          }`}
-                        >
-                          {item.type === 'index' ? '指数' : '基金'}
-                        </span>
-                        <h3 className="truncate text-sm font-medium text-slate-800 dark:text-gray-100">
-                          {item.name}
-                        </h3>
-                      </div>
-
-                      <div className="flex flex-col gap-1 md:hidden">
-                        <div className="flex items-center gap-1.5">
-                          <h3 className="truncate text-sm font-medium leading-tight text-slate-800 dark:text-gray-100">
-                            {item.name}
-                          </h3>
+                    <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                      <div className="min-w-0 flex-1 md:flex-[1.6] md:pr-4">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="rounded-full border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/92 px-2 py-1 text-[10px] font-semibold tracking-[0.14em] text-slate-700 dark:border-blue-400/20 dark:bg-blue-500/10 dark:text-blue-200">
+                            {item.code}
+                          </span>
                           <span
-                            className={`rounded-full px-2 py-0.5 text-[9px] font-bold whitespace-nowrap ${
+                            className={`rounded-full border px-2 py-1 text-[10px] font-semibold tracking-[0.14em] whitespace-nowrap shrink-0 ${
                               item.type === 'index'
-                                ? 'bg-[var(--app-shell-panel-strong)] text-slate-700 dark:bg-purple-900/40 dark:text-purple-400'
-                                : 'bg-[var(--app-shell-panel-strong)] text-slate-500 dark:bg-white/10 dark:text-gray-400'
+                                ? 'border-[var(--app-shell-line-strong)] bg-[var(--app-shell-panel-strong)] text-slate-700 dark:border-purple-400/20 dark:bg-purple-500/10 dark:text-purple-300'
+                                : 'border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-gray-400'
                             }`}
                           >
                             {item.type === 'index' ? '指数' : '基金'}
                           </span>
                         </div>
-                        <div className="flex items-center justify-between pr-2">
-                          <span className="text-xs text-slate-400">{item.code}</span>
-                        </div>
-                      </div>
-                    </div>
 
-                    <div className="hidden w-full flex-[4] grid-cols-4 items-start gap-4 text-right text-sm md:grid">
-                      <div className="text-left text-xs text-slate-500 dark:text-gray-400">
-                        <div className="flex items-center gap-1 text-slate-700 dark:text-gray-200">
-                          {item.anchorPrice.toFixed(4)}
-                          <span className="rounded bg-[var(--app-shell-panel-strong)] px-1 text-[10px] text-slate-400 dark:bg-white/5 dark:text-gray-500">
-                            {item.anchorDate}
-                          </span>
-                        </div>
-                        <div className="mt-1 text-slate-400 dark:text-gray-500">
-                          {item.currentPrice.toFixed(4)}
+                        <div className="mt-2">
+                          <h3 className="truncate text-[15px] font-semibold tracking-tight text-slate-900 dark:text-gray-50 md:text-base">
+                            {item.name}
+                          </h3>
+                          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-gray-400 md:hidden">
+                            <span>锚点 {item.anchorPrice.toFixed(4)}</span>
+                            <span>现价 {item.currentPrice.toFixed(4)}</span>
+                          </div>
                         </div>
                       </div>
-                      <div className={`font-medium ${getSignColor(item.dayChangePct)}`}>
-                        {formatPct(item.dayChangePct)}
-                      </div>
-                      <div />
-                      <div className={`font-bold ${getSignColor(anchorGainPct)}`}>
-                        {formatPct(anchorGainPct)}
-                      </div>
-                    </div>
 
-                    <div className="flex flex-none gap-2 text-right md:hidden">
-                      <div className="w-[4.9rem] rounded-2xl border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/90 px-3 py-3 dark:border-white/10 dark:bg-white/5">
-                        <div className={`text-base font-bold ${getSignColor(item.dayChangePct)}`}>
+                      <div className="hidden md:grid md:flex-[4] md:grid-cols-4 md:gap-4 md:text-right">
+                        <div className="text-left text-xs text-slate-500 dark:text-gray-400">
+                          <div className="font-semibold text-slate-700 dark:text-gray-200">
+                            {item.anchorPrice.toFixed(4)}
+                          </div>
+                          <div className="mt-1 text-slate-400 dark:text-gray-500">
+                            {item.currentPrice.toFixed(4)}
+                          </div>
+                        </div>
+                        <div className={`text-sm font-semibold ${getSignColor(item.dayChangePct)}`}>
                           {formatPct(item.dayChangePct)}
                         </div>
-                        <div className="mt-2 text-[10px] text-slate-400 dark:text-gray-500">
-                          现价 {item.currentPrice.toFixed(4)}
+                        <div className="text-sm font-semibold text-slate-700 dark:text-gray-200">
+                          {item.currentPrice.toFixed(4)}
+                        </div>
+                        <div className="flex flex-col items-end">
+                          <div className={`text-sm font-semibold ${getSignColor(anchorGainPct)}`}>
+                            {formatPct(anchorGainPct)}
+                          </div>
+                          <div className="mt-1 text-[10px] font-medium tracking-[0.14em] text-slate-400 dark:text-gray-500">
+                            {item.anchorDate}
+                          </div>
                         </div>
                       </div>
 
-                      <div className="w-[5.2rem] rounded-2xl border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/80 px-3 py-3 dark:border-white/10 dark:bg-white/5">
-                        <div className={`text-base font-bold ${getSignColor(anchorGainPct)}`}>
-                          {formatPct(anchorGainPct)}
+                      <div className="mt-2 flex items-stretch gap-1.5 md:hidden">
+                        <div className="min-w-0 flex-1 rounded-xl border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/90 px-2 py-2 text-right dark:border-white/10 dark:bg-white/5">
+                          <div
+                            className={`truncate text-[13px] font-black leading-none tracking-[-0.02em] ${getSignColor(item.dayChangePct)}`}
+                          >
+                            {formatPct(item.dayChangePct)}
+                          </div>
+                          <div className="mt-1 truncate text-[9px] font-semibold tracking-[0.1em] text-slate-400 dark:text-gray-500">
+                            现价 {item.currentPrice.toFixed(4)}
+                          </div>
                         </div>
-                        <div className="mt-2 flex flex-col items-end text-[10px] text-slate-400 dark:text-gray-500">
-                          <span>锚点 {item.anchorPrice.toFixed(4)}</span>
-                          <span className="origin-right scale-90 opacity-70">
-                            ({item.anchorDate})
-                          </span>
+
+                        <div className="min-w-0 flex-1 rounded-xl border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/80 px-2 py-2 text-right dark:border-white/10 dark:bg-white/5">
+                          <div
+                            className={`truncate text-[13px] font-black leading-none tracking-[-0.02em] ${getSignColor(anchorGainPct)}`}
+                          >
+                            {formatPct(anchorGainPct)}
+                          </div>
+                          <div className="mt-1 truncate text-[9px] font-semibold tracking-[0.1em] text-slate-400 dark:text-gray-500">
+                            锚点 {item.anchorPrice.toFixed(4)}
+                          </div>
+                          <div className="mt-0.5 truncate text-[9px] font-medium text-slate-400 dark:text-gray-500">
+                            {item.anchorDate}
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/components/__tests__/Watchlist.addHolding.test.tsx
+++ b/components/__tests__/Watchlist.addHolding.test.tsx
@@ -209,6 +209,33 @@ describe('Watchlist add holding from context menu', () => {
     });
   });
 
+  it('基金名称字号与字重对齐持仓列表样式', () => {
+    render(<Watchlist />);
+
+    const fundName = screen.getAllByRole('heading', { name: '未持有基金' })[0];
+    expect(fundName).toHaveClass('text-[15px]');
+    expect(fundName).toHaveClass('font-semibold');
+    expect(fundName).toHaveClass('md:text-base');
+  });
+
+  it('移动端指标卡采用持仓同款自适应卡片宽度', () => {
+    render(<Watchlist />);
+
+    const currentPriceLabel = screen
+      .getAllByText('现价 1.2345')
+      .find((node) => node.className.includes('text-[9px]'));
+    expect(currentPriceLabel).toBeDefined();
+    if (!currentPriceLabel) {
+      throw new Error('未找到移动端现价标签');
+    }
+    const mobileMetricCard = currentPriceLabel.parentElement;
+    expect(mobileMetricCard).not.toBeNull();
+
+    expect(mobileMetricCard).toHaveClass('min-w-0');
+    expect(mobileMetricCard).toHaveClass('flex-1');
+    expect(mobileMetricCard?.className).not.toContain('w-[4.9rem]');
+  });
+
   it('触摸滚动位移超过阈值时，长按不应弹出菜单', () => {
     vi.useFakeTimers();
     render(<Watchlist />);

--- a/services/__tests__/db.watchlistNameMigration.test.ts
+++ b/services/__tests__/db.watchlistNameMigration.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { db, migrateWatchlistNamesInDb } from '../db';
+
+describe('watchlist name migration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('仅更新名称含前缀代码的自选项', async () => {
+    vi.spyOn(db.watchlists, 'toArray').mockResolvedValue([
+      {
+        id: 1,
+        code: '110011',
+        name: '110011 易方达中小盘',
+        type: 'fund',
+        anchorPrice: 1.2,
+        anchorDate: '2026-03-20',
+        currentPrice: 1.21,
+        dayChangePct: 0.1,
+        lastUpdate: '2026-03-20',
+      },
+      {
+        id: 2,
+        code: '161903',
+        name: '万家行业优选',
+        type: 'fund',
+        anchorPrice: 1.2,
+        anchorDate: '2026-03-20',
+        currentPrice: 1.21,
+        dayChangePct: 0.1,
+        lastUpdate: '2026-03-20',
+      },
+    ]);
+    const updateSpy = vi.spyOn(db.watchlists, 'update').mockResolvedValue(1);
+
+    await migrateWatchlistNamesInDb();
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledWith(1, { name: '易方达中小盘' });
+  });
+});

--- a/services/__tests__/watchlistName.test.ts
+++ b/services/__tests__/watchlistName.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { pickWatchlistNameFromMorningstar, sanitizeWatchlistName } from '../watchlistName';
+
+describe('watchlist name helpers', () => {
+  it('优先使用 fundNameArr 作为自选名称', () => {
+    const name = pickWatchlistNameFromMorningstar({
+      fundClassId: 'cls-1',
+      fundName: '110011 易方达中小盘',
+      fundNameArr: '易方达中小盘',
+      symbol: '110011',
+      fundType: '混合型',
+    });
+
+    expect(name).toBe('易方达中小盘');
+  });
+
+  it('可去除名称前缀中的基金代码', () => {
+    expect(sanitizeWatchlistName('110011 易方达中小盘', '110011')).toBe('易方达中小盘');
+    expect(sanitizeWatchlistName('110011-易方达中小盘', '110011')).toBe('易方达中小盘');
+    expect(sanitizeWatchlistName('110011（LOF）', '110011')).toBe('（LOF）');
+  });
+
+  it('名称不含前缀代码时保持不变', () => {
+    expect(sanitizeWatchlistName('易方达中小盘', '110011')).toBe('易方达中小盘');
+  });
+});

--- a/services/db.ts
+++ b/services/db.ts
@@ -11,6 +11,7 @@ import {
   buildFundBackupPayload,
   parseAndNormalizeFundBackupPayload,
 } from './fundBackup';
+import { sanitizeWatchlistName } from './watchlistName';
 import { runFundQuotePipeline } from './fundQuotePipeline';
 import type { RefreshExecutionResult, RefreshExecutionStatus } from './refreshPolicy';
 
@@ -62,9 +63,22 @@ export const initDB = () => {
       if (accountsCount === 0) {
         await db.accounts.bulkAdd([{ name: 'Default', isDefault: true }]);
       }
+
+      await migrateWatchlistNamesInDb();
     })();
   }
   return initPromise;
+};
+
+export const migrateWatchlistNamesInDb = async () => {
+  const allItems = await db.watchlists.toArray();
+
+  for (const item of allItems) {
+    if (!item.id) continue;
+    const normalizedName = sanitizeWatchlistName(item.name, item.code);
+    if (normalizedName === item.name) continue;
+    await db.watchlists.update(item.id, { name: normalizedName });
+  }
 };
 
 /**

--- a/services/watchlistName.ts
+++ b/services/watchlistName.ts
@@ -1,0 +1,18 @@
+import type { MorningstarFund } from '../types';
+
+const escapeRegExp = (text: string) => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const sanitizeWatchlistName = (name: string, code?: string) => {
+  const trimmed = name.trim();
+  if (!trimmed || !code) return trimmed;
+
+  const escapedCode = escapeRegExp(code.trim());
+  const leadingCodePattern = new RegExp(`^${escapedCode}[\\s-_：:]*`);
+  const normalized = trimmed.replace(leadingCodePattern, '').trim();
+  return normalized || trimmed;
+};
+
+export const pickWatchlistNameFromMorningstar = (fund: MorningstarFund) => {
+  const preferred = fund.fundNameArr?.trim() || fund.fundName;
+  return sanitizeWatchlistName(preferred, fund.symbol);
+};


### PR DESCRIPTION
## Summary
- Align watchlist fund item layout, typography, and metric cards with the holdings page for consistent visual hierarchy.
- Prefer Morningstar `fundNameArr` when creating watchlist items from search results to avoid storing code-prefixed names.
- Add startup migration in `initDB` to sanitize existing watchlist names by removing leading fund code prefixes, with unit tests for helper and migration behavior.

## Verification
- npm run test -- services/__tests__/watchlistName.test.ts services/__tests__/db.watchlistNameMigration.test.ts
- npm run test -- components/__tests__/Watchlist.addHolding.test.tsx
- npm run lint -- components/AddWatchlistModal.tsx services/db.ts services/watchlistName.ts services/__tests__/watchlistName.test.ts services/__tests__/db.watchlistNameMigration.test.ts