### PR TITLE
feat(dashboard): add TotalAssetsModal with historical asset and profit charts

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -22,6 +22,7 @@ import type { Fund } from '../types';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useSettings } from '../services/SettingsContext';
 import { AiHoldingsAnalysisModal } from './AiHoldingsAnalysisModal';
+import { TotalAssetsModal } from './TotalAssetsModal';
 import { hasTouchMovedBeyondThreshold } from '../services/longPressGesture';
 import {
   AUTO_REFRESH_INTERVAL_MS,
@@ -145,6 +146,7 @@ export const Dashboard: React.FC = () => {
   );
   const [institutionMap, setInstitutionMap] = useState<Map<string, string> | null>(null);
   const [isAiAnalysisOpen, setIsAiAnalysisOpen] = useState(false);
+  const [isTotalAssetsOpen, setIsTotalAssetsOpen] = useState(false);
   const { autoRefresh } = useSettings();
 
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -768,10 +770,11 @@ export const Dashboard: React.FC = () => {
                   <button
                     key={filterKey}
                     onClick={() => setActiveFilter(filterKey)}
-                    className={`relative flex-shrink-0 overflow-hidden rounded-full border px-3 py-2 text-sm font-medium transition-all md:px-4 ${isActive
+                    className={`relative flex-shrink-0 overflow-hidden rounded-full border px-3 py-2 text-sm font-medium transition-all md:px-4 ${
+                      isActive
                         ? 'border-[var(--app-shell-line-strong)] bg-[var(--app-shell-panel-strong)] text-slate-800 shadow-[0_8px_24px_rgba(82,61,37,0.10)] dark:border-blue-400 dark:bg-blue-500/15 dark:text-blue-100 dark:shadow-none'
                         : 'border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)] text-slate-600 hover:border-[var(--app-shell-line-strong)] hover:text-slate-900 dark:border-white/10 dark:bg-white/5 dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-gray-100'
-                      }`}
+                    }`}
                   >
                     <span className="relative z-10">{label}</span>
                     {isActive && (
@@ -819,10 +822,11 @@ export const Dashboard: React.FC = () => {
                 <button
                   onClick={handleManualRefresh}
                   disabled={cooldown > 0 || isRefreshing}
-                  className={`relative flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border transition-transform active:scale-95 ${cooldown > 0 || isRefreshing
+                  className={`relative flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border transition-transform active:scale-95 ${
+                    cooldown > 0 || isRefreshing
                       ? 'cursor-not-allowed border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)] text-slate-500 dark:border-white/10 dark:bg-white/10 dark:text-gray-400'
                       : 'cursor-pointer border-[var(--app-shell-line-strong)] bg-[var(--app-shell-panel-strong)] text-slate-800 dark:border-blue-400/30 dark:bg-blue-500/15 dark:text-blue-100'
-                    }`}
+                  }`}
                 >
                   <Icons.Refresh size={14} className={isRefreshing ? 'animate-spin' : ''} />
                   {cooldown > 0 && !isRefreshing && (
@@ -847,9 +851,12 @@ export const Dashboard: React.FC = () => {
               <div className="mt-4 text-[11px] font-semibold tracking-wide text-slate-400 dark:text-gray-500">
                 总资产 (CNY)
               </div>
-              <div className="mt-1 text-4xl font-black tracking-[-0.04em] text-slate-900 dark:text-gray-50 md:text-[3.25rem] md:leading-tight">
+              <button
+                onClick={() => setIsTotalAssetsOpen(true)}
+                className="mt-1 text-4xl font-black tracking-[-0.04em] text-slate-900 dark:text-gray-50 md:text-[3.25rem] md:leading-tight hover:opacity-80 transition-opacity cursor-pointer text-left"
+              >
                 {showValues ? formatCurrency(summary.totalAssets) : '****'}
-              </div>
+              </button>
 
               <div className="mt-5 inline-flex items-center gap-2 rounded-full border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/80 px-3.5 py-1.5 transition-colors dark:border-white/5 dark:bg-white/5">
                 <span className="text-[12px] font-medium text-amber-600 dark:text-amber-500">
@@ -918,10 +925,11 @@ export const Dashboard: React.FC = () => {
                 <button
                   type="button"
                   onClick={() => setIsInstitutionGroupEnabled((prev) => !prev)}
-                  className={`rounded-full border p-1.5 transition-colors ${isInstitutionGroupEnabled
+                  className={`rounded-full border p-1.5 transition-colors ${
+                    isInstitutionGroupEnabled
                       ? 'border-indigo-400 bg-indigo-50 text-indigo-600 dark:border-indigo-400/30 dark:bg-indigo-500/15 dark:text-indigo-200'
                       : 'border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)] text-slate-400 hover:text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-gray-500 dark:hover:text-gray-200'
-                    }`}
+                  }`}
                   aria-label={t('common.groupByInstitution')}
                 >
                   <Icons.Layers size={14} />
@@ -1012,10 +1020,11 @@ export const Dashboard: React.FC = () => {
                 <button
                   type="button"
                   onClick={() => setIsInstitutionGroupEnabled((prev) => !prev)}
-                  className={`rounded-full border p-1.5 transition-colors ${isInstitutionGroupEnabled
+                  className={`rounded-full border p-1.5 transition-colors ${
+                    isInstitutionGroupEnabled
                       ? 'border-indigo-400 bg-indigo-50 text-indigo-600 dark:border-indigo-400/30 dark:bg-indigo-500/15 dark:text-indigo-200'
                       : 'border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)] text-slate-400 dark:border-white/10 dark:bg-white/5 dark:text-gray-500'
-                    }`}
+                  }`}
                   aria-label={t('common.groupByInstitution')}
                 >
                   <Icons.Layers size={14} />
@@ -1127,9 +1136,9 @@ export const Dashboard: React.FC = () => {
                   : dayChangeBaseNav !== undefined
                     ? fund.todayChangeIsEstimated
                       ? (fund.holdingShares *
-                        dayChangeBaseNav *
-                        (fund.estimatedDayChangePct ?? 0)) /
-                      100
+                          dayChangeBaseNav *
+                          (fund.estimatedDayChangePct ?? 0)) /
+                        100
                       : holdingValue - fund.holdingShares * dayChangeBaseNav
                     : fund.todayChangePreOpen
                       ? 0
@@ -1168,10 +1177,11 @@ export const Dashboard: React.FC = () => {
                   onTouchMove={handleTouchMove}
                   onTouchEnd={handleTouchEnd}
                   onTouchCancel={handleTouchEnd}
-                  className={`group relative cursor-pointer select-none border-b border-[var(--app-shell-line)]/80 px-4 py-3 transition-colors last:border-b-0 active:bg-[var(--app-shell-panel-strong)] dark:border-border-dark dark:active:bg-white/5 md:px-5 md:py-3.5 md:hover:bg-[var(--app-shell-panel-strong)]/72 dark:md:hover:bg-white/5 ${contextMenu?.fundId === fund.id
+                  className={`group relative cursor-pointer select-none border-b border-[var(--app-shell-line)]/80 px-4 py-3 transition-colors last:border-b-0 active:bg-[var(--app-shell-panel-strong)] dark:border-border-dark dark:active:bg-white/5 md:px-5 md:py-3.5 md:hover:bg-[var(--app-shell-panel-strong)]/72 dark:md:hover:bg-white/5 ${
+                    contextMenu?.fundId === fund.id
                       ? 'bg-[var(--app-shell-panel-strong)] dark:bg-white/10'
                       : ''
-                    }`}
+                  }`}
                 >
                   <div className="flex flex-col gap-3 md:flex-row md:items-center">
                     <div className="min-w-0 flex-1 md:flex-[1.6] md:pr-4">
@@ -1426,9 +1436,9 @@ export const Dashboard: React.FC = () => {
                         : dayChangeBaseNav !== undefined
                           ? fund.todayChangeIsEstimated
                             ? (fund.holdingShares *
-                              dayChangeBaseNav *
-                              (fund.estimatedDayChangePct ?? 0)) /
-                            100
+                                dayChangeBaseNav *
+                                (fund.estimatedDayChangePct ?? 0)) /
+                              100
                             : holdingValue - fund.holdingShares * dayChangeBaseNav
                           : fund.todayChangePreOpen
                             ? 0
@@ -1467,10 +1477,11 @@ export const Dashboard: React.FC = () => {
                         onTouchMove={handleTouchMove}
                         onTouchEnd={handleTouchEnd}
                         onTouchCancel={handleTouchEnd}
-                        className={`group relative cursor-pointer select-none border-b border-[var(--app-shell-line)]/80 px-4 py-3 transition-colors last:border-b-0 active:bg-[var(--app-shell-panel-strong)] dark:border-border-dark dark:active:bg-white/5 md:px-5 md:py-3.5 md:hover:bg-[var(--app-shell-panel-strong)]/72 dark:md:hover:bg-white/5 ${contextMenu?.fundId === fund.id
+                        className={`group relative cursor-pointer select-none border-b border-[var(--app-shell-line)]/80 px-4 py-3 transition-colors last:border-b-0 active:bg-[var(--app-shell-panel-strong)] dark:border-border-dark dark:active:bg-white/5 md:px-5 md:py-3.5 md:hover:bg-[var(--app-shell-panel-strong)]/72 dark:md:hover:bg-white/5 ${
+                          contextMenu?.fundId === fund.id
                             ? 'bg-[var(--app-shell-panel-strong)] dark:bg-white/10'
                             : ''
-                          }`}
+                        }`}
                       >
                         <div className="flex flex-col gap-3 md:flex-row md:items-center">
                           <div className="min-w-0 flex-1 md:flex-[1.6] md:pr-4">
@@ -1726,6 +1737,11 @@ export const Dashboard: React.FC = () => {
         isOpen={isAiAnalysisOpen}
         onClose={() => setIsAiAnalysisOpen(false)}
         holdingsSnapshot={holdingsSnapshot}
+      />
+      <TotalAssetsModal
+        isOpen={isTotalAssetsOpen}
+        onClose={() => setIsTotalAssetsOpen(false)}
+        funds={safeFunds}
       />
     </div>
   );

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
-import { db, initDB, calculateSummary, refreshFundData } from '../services/db';
+import {
+  db,
+  initDB,
+  calculateSummary,
+  refreshFundData,
+  saveTotalAssetsSnapshot,
+} from '../services/db';
 import {
   formatCurrency,
   formatSignedCurrency,
@@ -360,6 +366,12 @@ export const Dashboard: React.FC = () => {
   );
 
   const summary = useMemo(() => calculateSummary(filteredFunds), [filteredFunds]);
+
+  // 每日自动记录总资产快照
+  useEffect(() => {
+    saveTotalAssetsSnapshot(summary);
+  }, [summary]);
+
   const filterList =
     safeAccounts.length > 1
       ? ['All', ...safeAccounts.map((account) => account.name)]
@@ -1742,11 +1754,7 @@ export const Dashboard: React.FC = () => {
         onClose={() => setIsAiAnalysisOpen(false)}
         holdingsSnapshot={holdingsSnapshot}
       />
-      <TotalAssetsModal
-        isOpen={isTotalAssetsOpen}
-        onClose={() => setIsTotalAssetsOpen(false)}
-        funds={safeFunds}
-      />
+      <TotalAssetsModal isOpen={isTotalAssetsOpen} onClose={() => setIsTotalAssetsOpen(false)} />
     </div>
   );
 };

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -848,26 +848,30 @@ export const Dashboard: React.FC = () => {
                 </button>
               </div>
 
-              <div className="mt-4 text-[11px] font-semibold tracking-wide text-slate-400 dark:text-gray-500">
-                总资产 (CNY)
+              <div>
+                <div className="text-[11px] font-semibold tracking-wide text-slate-400 dark:text-gray-500">
+                  总资产 (CNY)
+                </div>
+                <button
+                  onClick={() => setIsTotalAssetsOpen(true)}
+                  className="mt-1 text-4xl font-black tracking-[-0.04em] text-slate-900 dark:text-gray-50 md:text-[3.25rem] md:leading-tight hover:opacity-80 transition-opacity cursor-pointer text-left"
+                >
+                  {showValues ? formatCurrency(summary.totalAssets) : '****'}
+                </button>
               </div>
-              <button
-                onClick={() => setIsTotalAssetsOpen(true)}
-                className="mt-1 text-4xl font-black tracking-[-0.04em] text-slate-900 dark:text-gray-50 md:text-[3.25rem] md:leading-tight hover:opacity-80 transition-opacity cursor-pointer text-left"
-              >
-                {showValues ? formatCurrency(summary.totalAssets) : '****'}
-              </button>
 
-              <div className="mt-5 inline-flex items-center gap-2 rounded-full border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/80 px-3.5 py-1.5 transition-colors dark:border-white/5 dark:bg-white/5">
-                <span className="text-[12px] font-medium text-amber-600 dark:text-amber-500">
-                  持有收益
-                </span>
-                <span className={`text-[13px] font-bold ${getSignColor(summary.holdingGain)}`}>
-                  {showValues ? formatSignedCurrency(summary.holdingGain) : '****'}
-                  <span className="ml-1 text-xs font-medium">
-                    ({showValues ? formatPct(summary.holdingGainPct) : '****'})
+              <div className="mt-4">
+                <div className="inline-flex items-center gap-2 rounded-full border border-[var(--app-shell-line)] bg-[var(--app-shell-panel-strong)]/80 px-3.5 py-1.5 transition-colors dark:border-white/5 dark:bg-white/5">
+                  <span className="text-[12px] font-medium text-amber-600 dark:text-amber-500">
+                    持有收益
                   </span>
-                </span>
+                  <span className={`text-[13px] font-bold ${getSignColor(summary.holdingGain)}`}>
+                    {showValues ? formatSignedCurrency(summary.holdingGain) : '****'}
+                    <span className="ml-1 text-xs font-medium">
+                      ({showValues ? formatPct(summary.holdingGainPct) : '****'})
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/components/TotalAssetsModal.tsx
+++ b/components/TotalAssetsModal.tsx
@@ -3,13 +3,13 @@ import * as echarts from 'echarts';
 import { ModalShell } from './ModalShell';
 import { Icons } from './Icon';
 import { useTheme } from '../services/ThemeContext';
-import type { Fund } from '../types';
+import { loadTotalAssetsHistory } from '../services/db';
 import {
-  aggregateTotalAssetsHistory,
   filterDataByTimeRange,
   rebaseDataToFirstValue,
   buildTotalAssetsChartOption,
   buildProfitChartOption,
+  snapshotsToChartData,
   type TimeRange,
   type TotalAssetsChartDataPoint,
 } from '../utils/totalAssetsChartUtils';
@@ -18,10 +18,9 @@ import { splitGrowthSeriesAtZero } from './fundDetailChartUtils';
 interface TotalAssetsModalProps {
   isOpen: boolean;
   onClose: () => void;
-  funds: Fund[];
 }
 
-export const TotalAssetsModal: React.FC<TotalAssetsModalProps> = ({ isOpen, onClose, funds }) => {
+export const TotalAssetsModal: React.FC<TotalAssetsModalProps> = ({ isOpen, onClose }) => {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
 
@@ -42,22 +41,22 @@ export const TotalAssetsModal: React.FC<TotalAssetsModalProps> = ({ isOpen, onCl
     return () => clearTimeout(timer);
   }, []);
 
-  // 数据获取
+  // 从 DB 加载历史快照
   useEffect(() => {
-    if (!isOpen || funds.length === 0) return;
+    if (!isOpen) return;
     setLoading(true);
     setError(null);
-    aggregateTotalAssetsHistory(funds)
-      .then((data) => {
-        setAllData(data);
+    loadTotalAssetsHistory()
+      .then((snapshots) => {
+        setAllData(snapshotsToChartData(snapshots));
         setLoading(false);
       })
       .catch((err: unknown) => {
-        console.error('Failed to aggregate total assets history', err);
+        console.error('Failed to load total assets history', err);
         setError('加载失败，请稍后重试');
         setLoading(false);
       });
-  }, [isOpen, funds]);
+  }, [isOpen]);
 
   // 图表渲染
   useEffect(() => {
@@ -155,7 +154,9 @@ export const TotalAssetsModal: React.FC<TotalAssetsModalProps> = ({ isOpen, onCl
       <div className="flex items-center justify-between px-6 pt-5 pb-3 shrink-0">
         <div>
           <h2 className="text-lg font-bold text-slate-900 dark:text-gray-50">总资产走势</h2>
-          <p className="text-xs text-slate-500 dark:text-gray-400 mt-0.5">历史总资产与收益曲线</p>
+          <p className="text-xs text-slate-500 dark:text-gray-400 mt-0.5">
+            历史总资产与收益曲线 · 每日自动记录
+          </p>
         </div>
         <button
           onClick={onClose}
@@ -200,7 +201,7 @@ export const TotalAssetsModal: React.FC<TotalAssetsModalProps> = ({ isOpen, onCl
 
         {!loading && !error && allData && allData.length === 0 && (
           <div className="flex items-center justify-center h-40 text-slate-400">
-            <span className="text-sm">暂无数据</span>
+            <span className="text-sm">暂无数据，每日打开持仓页将自动记录</span>
           </div>
         )}
 

--- a/components/TotalAssetsModal.tsx
+++ b/components/TotalAssetsModal.tsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as echarts from 'echarts';
+import { ModalShell } from './ModalShell';
+import { Icons } from './Icon';
+import { useTheme } from '../services/ThemeContext';
+import type { Fund } from '../types';
+import {
+  aggregateTotalAssetsHistory,
+  filterDataByTimeRange,
+  rebaseDataToFirstValue,
+  buildTotalAssetsChartOption,
+  buildProfitChartOption,
+  type TimeRange,
+  type TotalAssetsChartDataPoint,
+} from '../utils/totalAssetsChartUtils';
+import { splitGrowthSeriesAtZero } from './fundDetailChartUtils';
+
+interface TotalAssetsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  funds: Fund[];
+}
+
+export const TotalAssetsModal: React.FC<TotalAssetsModalProps> = ({ isOpen, onClose, funds }) => {
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [allData, setAllData] = useState<TotalAssetsChartDataPoint[] | null>(null);
+  const [timeRange, setTimeRange] = useState<TimeRange>('1Y');
+  const [chartReady, setChartReady] = useState(false);
+
+  const assetsChartRef = useRef<HTMLDivElement>(null);
+  const profitChartRef = useRef<HTMLDivElement>(null);
+  const assetsChartInstance = useRef<echarts.ECharts | null>(null);
+  const profitChartInstance = useRef<echarts.ECharts | null>(null);
+
+  // 延迟初始化，确保 DOM ref 就位
+  useEffect(() => {
+    const timer = setTimeout(() => setChartReady(true), 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // 数据获取
+  useEffect(() => {
+    if (!isOpen || funds.length === 0) return;
+    setLoading(true);
+    setError(null);
+    aggregateTotalAssetsHistory(funds)
+      .then((data) => {
+        setAllData(data);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        console.error('Failed to aggregate total assets history', err);
+        setError('加载失败，请稍后重试');
+        setLoading(false);
+      });
+  }, [isOpen, funds]);
+
+  // 图表渲染
+  useEffect(() => {
+    if (!chartReady || !allData) return;
+    if (typeof window !== 'undefined' && /jsdom/i.test(window.navigator.userAgent)) return;
+    if (!assetsChartRef.current || !profitChartRef.current) return;
+
+    const filtered = filterDataByTimeRange(allData, timeRange);
+    if (filtered.length === 0) return;
+
+    const isLargeSeries = filtered.length > 260;
+    const { dates, values } = rebaseDataToFirstValue(filtered);
+
+    // 总资产图表
+    const assetsDataPoints = filtered.map((d, i) => ({
+      value: values[i],
+      totalAssets: d.totalAssets,
+      profit: d.profit,
+    }));
+
+    if (!assetsChartInstance.current) {
+      assetsChartInstance.current = echarts.init(assetsChartRef.current);
+    }
+    assetsChartInstance.current.setOption(
+      buildTotalAssetsChartOption({
+        data: assetsDataPoints,
+        dates,
+        isDark,
+        isLargeSeries,
+      }),
+      { notMerge: true },
+    );
+
+    // 收益图表
+    const profitValues = filtered.map((d) => d.profit);
+    const { positive: positiveArea, negative: negativeArea } =
+      splitGrowthSeriesAtZero(profitValues);
+
+    if (!profitChartInstance.current) {
+      profitChartInstance.current = echarts.init(profitChartRef.current);
+    }
+    profitChartInstance.current.setOption(
+      buildProfitChartOption({
+        dates: filtered.map((d) => d.date),
+        profitValues,
+        positiveAreaData: positiveArea,
+        negativeAreaData: negativeArea,
+        isDark,
+        isLargeSeries,
+      }),
+      { notMerge: true },
+    );
+  }, [chartReady, allData, timeRange, isDark]);
+
+  // 窗口 resize
+  useEffect(() => {
+    if (!chartReady) return;
+    const handler = () => {
+      assetsChartInstance.current?.resize();
+      profitChartInstance.current?.resize();
+    };
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, [chartReady]);
+
+  // 关闭时 dispose 图表并重置状态
+  useEffect(() => {
+    if (!isOpen) {
+      assetsChartInstance.current?.dispose();
+      assetsChartInstance.current = null;
+      profitChartInstance.current?.dispose();
+      profitChartInstance.current = null;
+      setAllData(null);
+      setError(null);
+      setTimeRange('1Y');
+    }
+  }, [isOpen]);
+
+  // unmount cleanup
+  useEffect(() => {
+    return () => {
+      assetsChartInstance.current?.dispose();
+      profitChartInstance.current?.dispose();
+    };
+  }, []);
+
+  return (
+    <ModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      overlayId="total-assets-modal"
+      className="rounded-t-2xl sm:rounded-xl w-full h-[85vh] sm:h-auto sm:max-w-2xl overflow-hidden shadow-2xl flex flex-col max-h-[92vh] sm:max-h-[90vh]"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 pt-5 pb-3 shrink-0">
+        <div>
+          <h2 className="text-lg font-bold text-slate-900 dark:text-gray-50">总资产走势</h2>
+          <p className="text-xs text-slate-500 dark:text-gray-400 mt-0.5">历史总资产与收益曲线</p>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-white/10 transition-colors"
+          aria-label="关闭"
+        >
+          <Icons.X size={18} />
+        </button>
+      </div>
+
+      {/* 时间范围选择器 */}
+      <div className="flex gap-2 px-6 pb-3 shrink-0">
+        {(['1M', '3M', '6M', '1Y', 'ALL'] as TimeRange[]).map((range) => (
+          <button
+            key={range}
+            onClick={() => setTimeRange(range)}
+            className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+              timeRange === range
+                ? 'bg-slate-900 text-white dark:bg-white dark:text-slate-900'
+                : 'bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-gray-400 hover:bg-slate-200 dark:hover:bg-white/20'
+            }`}
+          >
+            {range}
+          </button>
+        ))}
+      </div>
+
+      {/* 图表区域 */}
+      <div className="flex-1 overflow-y-auto px-6 pb-6 space-y-6">
+        {loading && (
+          <div className="flex items-center justify-center h-40 text-slate-400">
+            <Icons.Refresh className="animate-spin" size={20} />
+            <span className="ml-2 text-sm">加载中...</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-center justify-center h-40 text-red-500">
+            <span className="text-sm">{error}</span>
+          </div>
+        )}
+
+        {!loading && !error && allData && allData.length === 0 && (
+          <div className="flex items-center justify-center h-40 text-slate-400">
+            <span className="text-sm">暂无数据</span>
+          </div>
+        )}
+
+        {!loading && !error && allData && allData.length > 0 && (
+          <>
+            <div>
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-gray-300 mb-2">
+                总资产
+              </h3>
+              <div ref={assetsChartRef} className="w-full h-64" />
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-gray-300 mb-2">收益</h3>
+              <div ref={profitChartRef} className="w-full h-64" />
+            </div>
+          </>
+        )}
+      </div>
+    </ModalShell>
+  );
+};

--- a/components/__tests__/Dashboard.institutionGroup.test.tsx
+++ b/components/__tests__/Dashboard.institutionGroup.test.tsx
@@ -44,6 +44,7 @@ vi.mock('../../services/db', () => ({
   initDB: mocked.initDB,
   refreshFundData: mocked.refreshFundData,
   calculateSummary: () => mocked.calculateSummary(),
+  saveTotalAssetsSnapshot: vi.fn(),
 }));
 
 vi.mock('../../services/i18n', () => ({

--- a/components/__tests__/Dashboard.sortPersistence.test.tsx
+++ b/components/__tests__/Dashboard.sortPersistence.test.tsx
@@ -43,6 +43,7 @@ vi.mock('../../services/db', () => ({
     holdingGain: 100,
     holdingGainPct: 10,
   }),
+  saveTotalAssetsSnapshot: vi.fn(),
 }));
 
 vi.mock('../../services/i18n', () => ({

--- a/components/__tests__/Dashboard.touchLongPress.test.tsx
+++ b/components/__tests__/Dashboard.touchLongPress.test.tsx
@@ -43,6 +43,7 @@ vi.mock('../../services/db', () => ({
     holdingGain: 100,
     holdingGainPct: 10,
   }),
+  saveTotalAssetsSnapshot: vi.fn(),
 }));
 
 vi.mock('../../services/i18n', () => ({

--- a/components/__tests__/TotalAssetsModal.test.tsx
+++ b/components/__tests__/TotalAssetsModal.test.tsx
@@ -1,17 +1,23 @@
 /// <reference types="vitest/globals" />
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
-const { mockAggregate, mockFilter, mockRebase, mockBuildAssets, mockBuildProfit } = vi.hoisted(
-  () => ({
-    mockAggregate: vi.fn(),
-    mockFilter: vi.fn(),
-    mockRebase: vi.fn(),
-    mockBuildAssets: vi.fn(),
-    mockBuildProfit: vi.fn(),
-  }),
-);
+const {
+  mockLoadHistory,
+  mockSnapshotsToChartData,
+  mockFilter,
+  mockRebase,
+  mockBuildAssets,
+  mockBuildProfit,
+} = vi.hoisted(() => ({
+  mockLoadHistory: vi.fn(),
+  mockSnapshotsToChartData: vi.fn(),
+  mockFilter: vi.fn(),
+  mockRebase: vi.fn(),
+  mockBuildAssets: vi.fn(),
+  mockBuildProfit: vi.fn(),
+}));
 
 const chartSpies = vi.hoisted(() => ({
   clear: vi.fn(),
@@ -22,16 +28,16 @@ const chartSpies = vi.hoisted(() => ({
 
 const mockEchartsInit = vi.hoisted(() => vi.fn());
 
+vi.mock('../../services/db', () => ({
+  loadTotalAssetsHistory: mockLoadHistory,
+}));
+
 vi.mock('../../utils/totalAssetsChartUtils', () => ({
-  aggregateTotalAssetsHistory: mockAggregate,
   filterDataByTimeRange: mockFilter,
   rebaseDataToFirstValue: mockRebase,
   buildTotalAssetsChartOption: mockBuildAssets,
   buildProfitChartOption: mockBuildProfit,
-}));
-
-vi.mock('../../services/i18n', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  snapshotsToChartData: mockSnapshotsToChartData,
 }));
 
 vi.mock('../../services/ThemeContext', () => ({
@@ -82,33 +88,16 @@ vi.mock('../Icon', () => ({
 }));
 
 import { TotalAssetsModal } from '../TotalAssetsModal';
-import type { Fund } from '../../types';
 import { resetOverlayStack } from '../../services/overlayStack';
 
-const mockFunds: Fund[] = [
-  {
-    code: '000001',
-    name: '测试基金A',
-    platform: '支付宝',
-    holdingShares: 100,
-    costPrice: 1.0,
-    currentNav: 1.2,
-    lastUpdate: '2026-05-09',
-    dayChangePct: 0.5,
-    dayChangeVal: 0.05,
-  },
-];
-
 const mockChartData = [
-  { date: '2025-01-01', totalAssets: 10000, profit: 0 },
-  { date: '2025-01-02', totalAssets: 10200, profit: 200 },
-  { date: '2025-01-03', totalAssets: 10150, profit: 150 },
+  { date: '2026-05-10', totalAssets: 100000, profit: 5000 },
+  { date: '2026-05-11', totalAssets: 102000, profit: 7000 },
 ];
 
 const defaultProps = {
   isOpen: false,
   onClose: vi.fn(),
-  funds: mockFunds,
 };
 
 const renderModal = (props = {}) => {
@@ -125,10 +114,12 @@ describe('TotalAssetsModal', () => {
       resize: chartSpies.resize,
       setOption: chartSpies.setOption,
     });
+    mockLoadHistory.mockResolvedValue([]);
+    mockSnapshotsToChartData.mockReturnValue([]);
+    mockFilter.mockReturnValue(mockChartData);
+    mockRebase.mockReturnValue({ dates: ['2026-05-10'], values: [0] });
     mockBuildAssets.mockReturnValue({});
     mockBuildProfit.mockReturnValue({});
-    mockFilter.mockReturnValue(mockChartData);
-    mockRebase.mockReturnValue({ dates: ['2025-01-01'], values: [0] });
   });
 
   afterEach(() => {
@@ -145,29 +136,39 @@ describe('TotalAssetsModal', () => {
     });
 
     it('isOpen=true 时显示加载状态', () => {
-      mockAggregate.mockReturnValue(new Promise(() => {})); // pending forever
+      mockLoadHistory.mockReturnValue(new Promise(() => {}));
       renderModal({ isOpen: true });
       expect(screen.getByText('加载中...')).toBeInTheDocument();
     });
 
     it('加载失败时显示错误提示', async () => {
-      mockAggregate.mockRejectedValue(new Error('Network error'));
+      mockLoadHistory.mockRejectedValue(new Error('DB error'));
       renderModal({ isOpen: true });
       await waitFor(() => {
         expect(screen.getByText(/加载失败/i)).toBeInTheDocument();
       });
     });
 
-    it('数据为空时显示暂无数据', async () => {
-      mockAggregate.mockResolvedValue([]);
+    it('数据为空时显示提示', async () => {
+      mockLoadHistory.mockResolvedValue([]);
+      mockSnapshotsToChartData.mockReturnValue([]);
       renderModal({ isOpen: true });
       await waitFor(() => {
-        expect(screen.getByText('暂无数据')).toBeInTheDocument();
+        expect(screen.getByText(/暂无数据/i)).toBeInTheDocument();
       });
     });
 
     it('数据就绪后显示图表区域', async () => {
-      mockAggregate.mockResolvedValue(mockChartData);
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       renderModal({ isOpen: true });
       await waitFor(() => {
         expect(screen.getByText('总资产')).toBeInTheDocument();
@@ -181,7 +182,16 @@ describe('TotalAssetsModal', () => {
   // ============================================================
   describe('时间范围切换', () => {
     it('渲染全部时间范围按钮', async () => {
-      mockAggregate.mockResolvedValue(mockChartData);
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       renderModal({ isOpen: true });
       await waitFor(() => {
         expect(screen.getByText('总资产')).toBeInTheDocument();
@@ -192,17 +202,24 @@ describe('TotalAssetsModal', () => {
     });
 
     it('点击时间范围按钮切换 active 样式', async () => {
-      mockAggregate.mockResolvedValue(mockChartData);
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       renderModal({ isOpen: true });
       await waitFor(() => {
         expect(screen.getByText('总资产')).toBeInTheDocument();
       });
 
-      // 默认 '1Y' 为 active
       const btn1Y = screen.getByText('1Y');
       expect(btn1Y.className).toContain('bg-slate-900');
 
-      // 点击 1M 后，1M 变为 active
       const btn1M = screen.getByText('1M');
       fireEvent.click(btn1M);
       expect(btn1M.className).toContain('bg-slate-900');
@@ -216,7 +233,16 @@ describe('TotalAssetsModal', () => {
   describe('关闭交互', () => {
     it('点击关闭按钮调用 onClose', async () => {
       const onClose = vi.fn();
-      mockAggregate.mockResolvedValue(mockChartData);
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       renderModal({ isOpen: true, onClose });
       await waitFor(() => {
         expect(screen.getByText('总资产')).toBeInTheDocument();
@@ -231,7 +257,16 @@ describe('TotalAssetsModal', () => {
 
     it('点击 backdrop 关闭 Modal', async () => {
       const onClose = vi.fn();
-      mockAggregate.mockResolvedValue(mockChartData);
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       renderModal({ isOpen: true, onClose });
       await waitFor(() => {
         expect(screen.getByText('总资产')).toBeInTheDocument();
@@ -246,11 +281,20 @@ describe('TotalAssetsModal', () => {
   });
 
   // ============================================================
-  // 图表 DOM 挂载（jsdom 环境下 ECharts 不初始化，仅验证 DOM 结构）
+  // 图表 DOM 挂载
   // ============================================================
   describe('图表 DOM 挂载', () => {
     it('数据就绪后渲染两个图表容器 div', async () => {
-      mockAggregate.mockResolvedValue(mockChartData);
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       renderModal({ isOpen: true });
       await waitFor(() => {
         expect(screen.getByText('总资产')).toBeInTheDocument();
@@ -261,7 +305,16 @@ describe('TotalAssetsModal', () => {
     });
 
     it('isOpen 变 false 后图表区域移除', async () => {
-      mockAggregate.mockResolvedValue(mockChartData);
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       const { rerender } = renderModal({ isOpen: true });
       await waitFor(() => {
         expect(screen.getByText('总资产')).toBeInTheDocument();
@@ -276,34 +329,25 @@ describe('TotalAssetsModal', () => {
   });
 
   // ============================================================
-  // 数据聚合
+  // 数据加载
   // ============================================================
-  describe('数据聚合', () => {
-    it('isOpen 变 true 时触发 aggregateTotalAssetsHistory', async () => {
-      mockAggregate.mockResolvedValue(mockChartData);
+  describe('数据加载', () => {
+    it('isOpen 变 true 时调用 loadTotalAssetsHistory', async () => {
+      mockLoadHistory.mockResolvedValue([
+        {
+          date: '2026-05-10',
+          totalAssets: 100000,
+          holdingGain: 5000,
+          holdingGainPct: 5,
+          dayGain: 1000,
+        },
+      ]);
+      mockSnapshotsToChartData.mockReturnValue(mockChartData);
       renderModal({ isOpen: true });
 
       await waitFor(() => {
-        expect(mockAggregate).toHaveBeenCalledWith(mockFunds);
-      });
-    });
-
-    it('funds 变化时重新聚合', async () => {
-      mockAggregate.mockResolvedValue(mockChartData);
-      const { rerender } = renderModal({ isOpen: true });
-
-      const newFunds: Fund[] = [{ ...mockFunds[0], code: '000002', holdingShares: 200 }];
-
-      rerender(
-        React.createElement(TotalAssetsModal, {
-          ...defaultProps,
-          isOpen: true,
-          funds: newFunds,
-        }),
-      );
-
-      await waitFor(() => {
-        expect(mockAggregate).toHaveBeenCalledWith(newFunds);
+        expect(mockLoadHistory).toHaveBeenCalled();
+        expect(mockSnapshotsToChartData).toHaveBeenCalled();
       });
     });
   });

--- a/components/__tests__/TotalAssetsModal.test.tsx
+++ b/components/__tests__/TotalAssetsModal.test.tsx
@@ -1,0 +1,310 @@
+/// <reference types="vitest/globals" />
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+const { mockAggregate, mockFilter, mockRebase, mockBuildAssets, mockBuildProfit } = vi.hoisted(
+  () => ({
+    mockAggregate: vi.fn(),
+    mockFilter: vi.fn(),
+    mockRebase: vi.fn(),
+    mockBuildAssets: vi.fn(),
+    mockBuildProfit: vi.fn(),
+  }),
+);
+
+const chartSpies = vi.hoisted(() => ({
+  clear: vi.fn(),
+  dispose: vi.fn(),
+  resize: vi.fn(),
+  setOption: vi.fn(),
+}));
+
+const mockEchartsInit = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/totalAssetsChartUtils', () => ({
+  aggregateTotalAssetsHistory: mockAggregate,
+  filterDataByTimeRange: mockFilter,
+  rebaseDataToFirstValue: mockRebase,
+  buildTotalAssetsChartOption: mockBuildAssets,
+  buildProfitChartOption: mockBuildProfit,
+}));
+
+vi.mock('../../services/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../services/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+vi.mock('../../services/overlayRegistration', () => ({
+  useOverlayRegistration: vi.fn(),
+}));
+
+vi.mock('../../services/useEdgeSwipe', () => ({
+  resetDragState: vi.fn(),
+  useEdgeSwipe: () => ({
+    isDragging: false,
+    activeOverlayId: null,
+    setDragState: vi.fn(),
+    snapBackX: null,
+  }),
+}));
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ initial: _i, animate: _a, exit: _e, ...rest }: Record<string, unknown>) => (
+      <div {...rest} />
+    ),
+  },
+}));
+
+vi.mock('echarts', () => ({
+  init: mockEchartsInit.mockReturnValue({
+    clear: chartSpies.clear,
+    dispose: chartSpies.dispose,
+    resize: chartSpies.resize,
+    setOption: chartSpies.setOption,
+  }),
+  getInstanceByDom: vi.fn(() => undefined),
+  graphic: { LinearGradient: vi.fn() },
+}));
+
+vi.mock('../Icon', () => ({
+  Icons: {
+    X: (props: Record<string, unknown>) =>
+      React.createElement('span', { ...props, 'data-icon': 'x' }, '×'),
+    Refresh: (props: Record<string, unknown>) =>
+      React.createElement('span', { ...props, 'data-icon': 'refresh' }, '↻'),
+  },
+}));
+
+import { TotalAssetsModal } from '../TotalAssetsModal';
+import type { Fund } from '../../types';
+import { resetOverlayStack } from '../../services/overlayStack';
+
+const mockFunds: Fund[] = [
+  {
+    code: '000001',
+    name: '测试基金A',
+    platform: '支付宝',
+    holdingShares: 100,
+    costPrice: 1.0,
+    currentNav: 1.2,
+    lastUpdate: '2026-05-09',
+    dayChangePct: 0.5,
+    dayChangeVal: 0.05,
+  },
+];
+
+const mockChartData = [
+  { date: '2025-01-01', totalAssets: 10000, profit: 0 },
+  { date: '2025-01-02', totalAssets: 10200, profit: 200 },
+  { date: '2025-01-03', totalAssets: 10150, profit: 150 },
+];
+
+const defaultProps = {
+  isOpen: false,
+  onClose: vi.fn(),
+  funds: mockFunds,
+};
+
+const renderModal = (props = {}) => {
+  return render(React.createElement(TotalAssetsModal, { ...defaultProps, ...props }));
+};
+
+describe('TotalAssetsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetOverlayStack();
+    mockEchartsInit.mockReturnValue({
+      clear: chartSpies.clear,
+      dispose: chartSpies.dispose,
+      resize: chartSpies.resize,
+      setOption: chartSpies.setOption,
+    });
+    mockBuildAssets.mockReturnValue({});
+    mockBuildProfit.mockReturnValue({});
+    mockFilter.mockReturnValue(mockChartData);
+    mockRebase.mockReturnValue({ dates: ['2025-01-01'], values: [0] });
+  });
+
+  afterEach(() => {
+    resetOverlayStack();
+  });
+
+  // ============================================================
+  // 状态展示
+  // ============================================================
+  describe('状态展示', () => {
+    it('isOpen=false 时不在 DOM 中', () => {
+      renderModal({ isOpen: false });
+      expect(screen.queryByText('总资产走势')).toBeNull();
+    });
+
+    it('isOpen=true 时显示加载状态', () => {
+      mockAggregate.mockReturnValue(new Promise(() => {})); // pending forever
+      renderModal({ isOpen: true });
+      expect(screen.getByText('加载中...')).toBeInTheDocument();
+    });
+
+    it('加载失败时显示错误提示', async () => {
+      mockAggregate.mockRejectedValue(new Error('Network error'));
+      renderModal({ isOpen: true });
+      await waitFor(() => {
+        expect(screen.getByText(/加载失败/i)).toBeInTheDocument();
+      });
+    });
+
+    it('数据为空时显示暂无数据', async () => {
+      mockAggregate.mockResolvedValue([]);
+      renderModal({ isOpen: true });
+      await waitFor(() => {
+        expect(screen.getByText('暂无数据')).toBeInTheDocument();
+      });
+    });
+
+    it('数据就绪后显示图表区域', async () => {
+      mockAggregate.mockResolvedValue(mockChartData);
+      renderModal({ isOpen: true });
+      await waitFor(() => {
+        expect(screen.getByText('总资产')).toBeInTheDocument();
+        expect(screen.getByText('收益')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ============================================================
+  // 时间范围切换
+  // ============================================================
+  describe('时间范围切换', () => {
+    it('渲染全部时间范围按钮', async () => {
+      mockAggregate.mockResolvedValue(mockChartData);
+      renderModal({ isOpen: true });
+      await waitFor(() => {
+        expect(screen.getByText('总资产')).toBeInTheDocument();
+      });
+      for (const range of ['1M', '3M', '6M', '1Y', 'ALL']) {
+        expect(screen.getByText(range)).toBeInTheDocument();
+      }
+    });
+
+    it('点击时间范围按钮切换 active 样式', async () => {
+      mockAggregate.mockResolvedValue(mockChartData);
+      renderModal({ isOpen: true });
+      await waitFor(() => {
+        expect(screen.getByText('总资产')).toBeInTheDocument();
+      });
+
+      // 默认 '1Y' 为 active
+      const btn1Y = screen.getByText('1Y');
+      expect(btn1Y.className).toContain('bg-slate-900');
+
+      // 点击 1M 后，1M 变为 active
+      const btn1M = screen.getByText('1M');
+      fireEvent.click(btn1M);
+      expect(btn1M.className).toContain('bg-slate-900');
+      expect(btn1Y.className).not.toContain('bg-slate-900');
+    });
+  });
+
+  // ============================================================
+  // 关闭交互
+  // ============================================================
+  describe('关闭交互', () => {
+    it('点击关闭按钮调用 onClose', async () => {
+      const onClose = vi.fn();
+      mockAggregate.mockResolvedValue(mockChartData);
+      renderModal({ isOpen: true, onClose });
+      await waitFor(() => {
+        expect(screen.getByText('总资产')).toBeInTheDocument();
+      });
+
+      const closeBtn = document.querySelector('[data-icon="x"]') as HTMLElement;
+      if (closeBtn) {
+        fireEvent.click(closeBtn);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('点击 backdrop 关闭 Modal', async () => {
+      const onClose = vi.fn();
+      mockAggregate.mockResolvedValue(mockChartData);
+      renderModal({ isOpen: true, onClose });
+      await waitFor(() => {
+        expect(screen.getByText('总资产')).toBeInTheDocument();
+      });
+
+      const backdrop = document.querySelector('.backdrop-blur-md');
+      if (backdrop) {
+        fireEvent.click(backdrop);
+        expect(onClose).toHaveBeenCalled();
+      }
+    });
+  });
+
+  // ============================================================
+  // 图表 DOM 挂载（jsdom 环境下 ECharts 不初始化，仅验证 DOM 结构）
+  // ============================================================
+  describe('图表 DOM 挂载', () => {
+    it('数据就绪后渲染两个图表容器 div', async () => {
+      mockAggregate.mockResolvedValue(mockChartData);
+      renderModal({ isOpen: true });
+      await waitFor(() => {
+        expect(screen.getByText('总资产')).toBeInTheDocument();
+      });
+
+      const chartContainers = document.querySelectorAll('.h-64');
+      expect(chartContainers).toHaveLength(2);
+    });
+
+    it('isOpen 变 false 后图表区域移除', async () => {
+      mockAggregate.mockResolvedValue(mockChartData);
+      const { rerender } = renderModal({ isOpen: true });
+      await waitFor(() => {
+        expect(screen.getByText('总资产')).toBeInTheDocument();
+      });
+
+      rerender(React.createElement(TotalAssetsModal, { ...defaultProps, isOpen: false }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('总资产')).toBeNull();
+      });
+    });
+  });
+
+  // ============================================================
+  // 数据聚合
+  // ============================================================
+  describe('数据聚合', () => {
+    it('isOpen 变 true 时触发 aggregateTotalAssetsHistory', async () => {
+      mockAggregate.mockResolvedValue(mockChartData);
+      renderModal({ isOpen: true });
+
+      await waitFor(() => {
+        expect(mockAggregate).toHaveBeenCalledWith(mockFunds);
+      });
+    });
+
+    it('funds 变化时重新聚合', async () => {
+      mockAggregate.mockResolvedValue(mockChartData);
+      const { rerender } = renderModal({ isOpen: true });
+
+      const newFunds: Fund[] = [{ ...mockFunds[0], code: '000002', holdingShares: 200 }];
+
+      rerender(
+        React.createElement(TotalAssetsModal, {
+          ...defaultProps,
+          isOpen: true,
+          funds: newFunds,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockAggregate).toHaveBeenCalledWith(newFunds);
+      });
+    });
+  });
+});

--- a/services/api.ts
+++ b/services/api.ts
@@ -127,7 +127,7 @@ const normalizeTicker = (ticker: string) => ticker.replace(/\D/g, '');
 
 const buildCodesKey = (codes: string[]) => codes.slice().sort().join(',');
 
-const withCache = async <T>(params: {
+export const withCache = async <T>(params: {
   key: string;
   ttlMs: number;
   force?: boolean;

--- a/services/api.ts
+++ b/services/api.ts
@@ -127,7 +127,7 @@ const normalizeTicker = (ticker: string) => ticker.replace(/\D/g, '');
 
 const buildCodesKey = (codes: string[]) => codes.slice().sort().join(',');
 
-export const withCache = async <T>(params: {
+const withCache = async <T>(params: {
   key: string;
   ttlMs: number;
   force?: boolean;

--- a/services/db.ts
+++ b/services/db.ts
@@ -1,5 +1,12 @@
 import Dexie, { type Table } from 'dexie';
-import type { Fund, Account, AssetSummary, WatchlistItem, PendingTransaction } from '../types';
+import type {
+  Fund,
+  Account,
+  AssetSummary,
+  WatchlistItem,
+  PendingTransaction,
+  TotalAssetsSnapshot,
+} from '../types';
 import {
   fetchHistoricalFundNavWithDate,
   checkIsMarketTrading,
@@ -33,6 +40,7 @@ class XiaoHuYangJiDB extends Dexie {
   funds!: Table<Fund>;
   accounts!: Table<Account>;
   watchlists!: Table<WatchlistItem>;
+  totalAssetsHistory!: Table<TotalAssetsSnapshot>;
 
   constructor() {
     super('XiaoHuYangJiDB');
@@ -55,6 +63,13 @@ class XiaoHuYangJiDB extends Dexie {
       funds: '++id, code, platform, name',
       accounts: '++id, name',
       watchlists: '++id, code, type, name',
+    });
+    // Version 5: 每日总资产快照表
+    this.version(5).stores({
+      funds: '++id, code, platform, name',
+      accounts: '++id, name',
+      watchlists: '++id, code, type, name',
+      totalAssetsHistory: '++id, &date',
     });
   }
 }
@@ -827,6 +842,32 @@ export const calculateSummary = (funds: Fund[]): AssetSummary => {
     holdingGain,
     holdingGainPct,
   };
+};
+
+// === 总资产快照 ===
+
+/**
+ * 保存今日总资产快照。如果今日已有记录则跳过（每日仅一条）。
+ * 应在 calculateSummary 后调用。
+ */
+export const saveTotalAssetsSnapshot = async (summary: AssetSummary): Promise<void> => {
+  const today = getLocalDateString();
+  const existing = await db.totalAssetsHistory.where('date').equals(today).first();
+  if (existing) return; // 今日已记录
+  await db.totalAssetsHistory.put({
+    date: today,
+    totalAssets: summary.totalAssets,
+    holdingGain: summary.holdingGain,
+    holdingGainPct: summary.holdingGainPct,
+    dayGain: summary.totalDayGain,
+  });
+};
+
+/**
+ * 加载全部总资产历史快照，按日期升序排列。
+ */
+export const loadTotalAssetsHistory = async (): Promise<TotalAssetsSnapshot[]> => {
+  return db.totalAssetsHistory.orderBy('date').toArray();
 };
 
 // === 导入导出 ===

--- a/services/i18n.tsx
+++ b/services/i18n.tsx
@@ -311,6 +311,13 @@ const dictionary = {
     filters: {
       Default: 'Default',
     },
+    totalAssets: {
+      title: 'Total Assets',
+      subtitle: 'Historical total assets and profit',
+      assetsChartTitle: 'Total Assets',
+      profitChartTitle: 'Profit',
+      noData: 'No data available',
+    },
   },
   zh: {
     common: {
@@ -612,6 +619,13 @@ const dictionary = {
     },
     filters: {
       Default: '默认',
+    },
+    totalAssets: {
+      title: '总资产走势',
+      subtitle: '历史总资产与收益曲线',
+      assetsChartTitle: '总资产',
+      profitChartTitle: '收益',
+      noData: '暂无数据',
     },
   },
 };

--- a/types.ts
+++ b/types.ts
@@ -82,6 +82,20 @@ export interface AssetSummary {
   holdingGainPct: number;
 }
 
+/** 每日总资产快照，用于总资产走势图 */
+export interface TotalAssetsSnapshot {
+  /** 日期，格式 YYYY-MM-DD */
+  date: string;
+  /** 总资产 (CNY) */
+  totalAssets: number;
+  /** 持有收益 (CNY) */
+  holdingGain: number;
+  /** 持有收益率 (%) */
+  holdingGainPct: number;
+  /** 当日收益 (CNY) */
+  dayGain: number;
+}
+
 export type TabType = 'holding' | 'watchlist' | 'services' | 'news' | 'settings';
 
 export interface MarketIndex {

--- a/utils/__tests__/totalAssetsChartUtils.test.ts
+++ b/utils/__tests__/totalAssetsChartUtils.test.ts
@@ -1,0 +1,349 @@
+/// <reference types="vitest/globals" />
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockFetchEastMoneyPingzhongData, mockWithCache } = vi.hoisted(() => ({
+  mockFetchEastMoneyPingzhongData: vi.fn(),
+  mockWithCache: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({
+  fetchEastMoneyPingzhongData: mockFetchEastMoneyPingzhongData,
+  withCache: mockWithCache,
+}));
+
+import {
+  computeTimeRangeCutoff,
+  filterDataByTimeRange,
+  rebaseDataToFirstValue,
+  aggregateTotalAssetsHistory,
+  buildTotalAssetsChartOption,
+  buildProfitChartOption,
+  type TotalAssetsChartDataPoint,
+} from '../totalAssetsChartUtils';
+
+import type { Fund } from '../../types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithCache.mockImplementation(async <T>({ fetcher }: { fetcher: () => Promise<T> }) =>
+    fetcher(),
+  );
+});
+
+// ============================================================
+// computeTimeRangeCutoff
+// ============================================================
+describe('computeTimeRangeCutoff', () => {
+  it('1M 返回约 1 个月前的日期', () => {
+    const now = new Date();
+    const cutoff = computeTimeRangeCutoff('1M');
+    const expected = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
+    expect(cutoff.getMonth()).toBe(expected.getMonth());
+    expect(cutoff.getDate()).toBe(expected.getDate());
+  });
+
+  it('3M 返回约 3 个月前的日期', () => {
+    const now = new Date();
+    const cutoff = computeTimeRangeCutoff('3M');
+    const expected = new Date(now.getFullYear(), now.getMonth() - 3, now.getDate());
+    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
+    expect(cutoff.getMonth()).toBe(expected.getMonth());
+  });
+
+  it('6M 返回约 6 个月前的日期', () => {
+    const now = new Date();
+    const cutoff = computeTimeRangeCutoff('6M');
+    const expected = new Date(now.getFullYear(), now.getMonth() - 6, now.getDate());
+    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
+    expect(cutoff.getMonth()).toBe(expected.getMonth());
+  });
+
+  it('1Y 返回约 1 年前的日期', () => {
+    const now = new Date();
+    const cutoff = computeTimeRangeCutoff('1Y');
+    const expected = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
+    expect(cutoff.getMonth()).toBe(expected.getMonth());
+  });
+
+  it('ALL 返回 epoch 日期', () => {
+    const cutoff = computeTimeRangeCutoff('ALL');
+    expect(cutoff.getTime()).toBe(0);
+  });
+});
+
+// ============================================================
+// filterDataByTimeRange
+// ============================================================
+describe('filterDataByTimeRange', () => {
+  const data: TotalAssetsChartDataPoint[] = [
+    { date: '2025-01-01', totalAssets: 10000, profit: 0 },
+    { date: '2025-06-15', totalAssets: 12000, profit: 2000 },
+    { date: '2025-12-01', totalAssets: 15000, profit: 5000 },
+    { date: '2026-03-01', totalAssets: 18000, profit: 8000 },
+  ];
+
+  it('ALL 返回全部数据', () => {
+    const filtered = filterDataByTimeRange(data, 'ALL');
+    expect(filtered).toHaveLength(4);
+  });
+
+  it('1Y 过滤掉超过一年的数据', () => {
+    const filtered = filterDataByTimeRange(data, '1Y');
+    // 只有最近一年的数据（从今天算约往前一年）
+    expect(filtered.length).toBeGreaterThanOrEqual(0);
+    expect(filtered.length).toBeLessThanOrEqual(4);
+    if (filtered.length > 0) {
+      // 确保 filtered 中的所有日期都不早于一年前的今天
+      const oneYearAgo = new Date();
+      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      for (const d of filtered) {
+        expect(new Date(d.date).getTime()).toBeGreaterThanOrEqual(
+          new Date(oneYearAgo.getFullYear(), oneYearAgo.getMonth(), oneYearAgo.getDate()).getTime(),
+        );
+      }
+    }
+  });
+});
+
+// ============================================================
+// rebaseDataToFirstValue
+// ============================================================
+describe('rebaseDataToFirstValue', () => {
+  it('空数组返回空结果', () => {
+    const result = rebaseDataToFirstValue([]);
+    expect(result.dates).toEqual([]);
+    expect(result.values).toEqual([]);
+  });
+
+  it('以首个值为基准计算百分比', () => {
+    const data: TotalAssetsChartDataPoint[] = [
+      { date: '2025-01-01', totalAssets: 10000, profit: 0 },
+      { date: '2025-01-02', totalAssets: 10200, profit: 200 },
+      { date: '2025-01-03', totalAssets: 9800, profit: -200 },
+    ];
+    const result = rebaseDataToFirstValue(data);
+    expect(result.dates).toEqual(['2025-01-01', '2025-01-02', '2025-01-03']);
+    expect(result.values[0]).toBe(0);
+    expect(result.values[1]).toBe(2);
+    expect(result.values[2]).toBe(-2);
+  });
+
+  it('首个值为 0 时返回全 0', () => {
+    const data: TotalAssetsChartDataPoint[] = [
+      { date: '2025-01-01', totalAssets: 0, profit: 0 },
+      { date: '2025-01-02', totalAssets: 100, profit: 100 },
+    ];
+    const result = rebaseDataToFirstValue(data);
+    expect(result.values[1]).toBe(0);
+  });
+});
+
+// ============================================================
+// aggregateTotalAssetsHistory
+// ============================================================
+describe('aggregateTotalAssetsHistory', () => {
+  const baseFund: Fund = {
+    code: '000001',
+    name: '测试基金A',
+    platform: '支付宝',
+    holdingShares: 100,
+    costPrice: 1.0,
+    currentNav: 1.2,
+    lastUpdate: '2026-05-09',
+    dayChangePct: 0.5,
+    dayChangeVal: 0.05,
+  };
+
+  it('空 funds 返回空数组', async () => {
+    const result = await aggregateTotalAssetsHistory([]);
+    expect(result).toEqual([]);
+  });
+
+  it('所有基金 holdingShares 为 0 时返回空数组', async () => {
+    const result = await aggregateTotalAssetsHistory([{ ...baseFund, holdingShares: 0 }]);
+    expect(result).toEqual([]);
+  });
+
+  it('双基金重叠日期聚合正确', async () => {
+    mockFetchEastMoneyPingzhongData
+      .mockResolvedValueOnce({
+        netWorthTrend: [
+          { x: new Date('2025-01-01').getTime(), y: 1.0, equityReturn: 0, unitMoney: '' },
+          { x: new Date('2025-01-02').getTime(), y: 1.1, equityReturn: 0, unitMoney: '' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        netWorthTrend: [
+          { x: new Date('2025-01-01').getTime(), y: 2.0, equityReturn: 0, unitMoney: '' },
+          { x: new Date('2025-01-02').getTime(), y: 2.2, equityReturn: 0, unitMoney: '' },
+        ],
+      });
+
+    const funds: Fund[] = [
+      { ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 },
+      { ...baseFund, code: '000002', holdingShares: 50, costPrice: 2.0 },
+    ];
+
+    const result = await aggregateTotalAssetsHistory(funds);
+
+    expect(result).toHaveLength(2);
+    // 2025-01-01: 100*1.0 + 50*2.0 = 200
+    expect(result[0].date).toBe('2025-01-01');
+    expect(result[0].totalAssets).toBe(200);
+    expect(result[0].profit).toBe(0); // 200 - (100*1 + 50*2) = 0
+    // 2025-01-02: 100*1.1 + 50*2.2 = 220
+    expect(result[1].date).toBe('2025-01-02');
+    expect(result[1].totalAssets).toBe(220);
+    expect(result[1].profit).toBe(20); // 220 - 200 = 20
+  });
+
+  it('基金返回 null 时跳过该基金，使用其他基金数据', async () => {
+    mockFetchEastMoneyPingzhongData.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      netWorthTrend: [
+        { x: new Date('2025-01-01').getTime(), y: 2.0, equityReturn: 0, unitMoney: '' },
+      ],
+    });
+
+    const funds: Fund[] = [
+      { ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 },
+      { ...baseFund, code: '000002', holdingShares: 50, costPrice: 2.0 },
+    ];
+
+    const result = await aggregateTotalAssetsHistory(funds);
+
+    expect(result).toHaveLength(1);
+    // 只有基金B的数据：50 * 2.0 = 100
+    expect(result[0].totalAssets).toBe(100);
+    // profit = 100 - (100*1 + 50*2) = 100 - 200 = -100
+    expect(result[0].profit).toBe(-100);
+  });
+
+  it('不同日期范围前向填充', async () => {
+    // 基金A 只有 1月1日 和 1月3日 的数据，基金B 有 1月1日 到 1月3日
+    mockFetchEastMoneyPingzhongData
+      .mockResolvedValueOnce({
+        netWorthTrend: [
+          { x: new Date('2025-01-01').getTime(), y: 1.0, equityReturn: 0, unitMoney: '' },
+          { x: new Date('2025-01-03').getTime(), y: 1.5, equityReturn: 0, unitMoney: '' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        netWorthTrend: [
+          { x: new Date('2025-01-01').getTime(), y: 2.0, equityReturn: 0, unitMoney: '' },
+          { x: new Date('2025-01-02').getTime(), y: 2.1, equityReturn: 0, unitMoney: '' },
+          { x: new Date('2025-01-03').getTime(), y: 2.3, equityReturn: 0, unitMoney: '' },
+        ],
+      });
+
+    const funds: Fund[] = [
+      { ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 },
+      { ...baseFund, code: '000002', holdingShares: 50, costPrice: 2.0 },
+    ];
+
+    const result = await aggregateTotalAssetsHistory(funds);
+
+    expect(result).toHaveLength(3);
+    // 2025-01-01: 100*1.0 + 50*2.0 = 200
+    expect(result[0].totalAssets).toBe(200);
+    // 2025-01-02: 100*1.0(forward-fill) + 50*2.1 = 205
+    expect(result[1].totalAssets).toBe(205);
+    // 2025-01-03: 100*1.5 + 50*2.3 = 265
+    expect(result[2].totalAssets).toBe(265);
+  });
+
+  it('使用 withCache 缓存结果', async () => {
+    mockFetchEastMoneyPingzhongData.mockResolvedValue({
+      netWorthTrend: [
+        { x: new Date('2025-01-01').getTime(), y: 1.0, equityReturn: 0, unitMoney: '' },
+      ],
+    });
+
+    const funds: Fund[] = [{ ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 }];
+
+    await aggregateTotalAssetsHistory(funds);
+
+    expect(mockWithCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: expect.stringContaining('total-assets:'),
+        ttlMs: 30 * 60 * 1000,
+      }),
+    );
+  });
+});
+
+// ============================================================
+// buildTotalAssetsChartOption
+// ============================================================
+describe('buildTotalAssetsChartOption', () => {
+  it('返回正确的 chart option 结构', () => {
+    const option = buildTotalAssetsChartOption({
+      data: [
+        { value: 0, totalAssets: 10000, profit: 0 },
+        { value: 5, totalAssets: 10500, profit: 500 },
+      ],
+      dates: ['2025-01-01', '2025-01-02'],
+      isDark: false,
+      isLargeSeries: false,
+    });
+
+    expect(option.backgroundColor).toBe('transparent');
+    expect(option.grid).toBeDefined();
+    expect(option.xAxis).toBeDefined();
+    expect(option.yAxis).toBeDefined();
+    expect(option.series).toBeDefined();
+    expect(Array.isArray(option.series)).toBe(true);
+    expect(option.series).toHaveLength(1);
+  });
+
+  it('大数据集启用采样', () => {
+    const option = buildTotalAssetsChartOption({
+      data: [{ value: 0, totalAssets: 10000, profit: 0 }],
+      dates: ['2025-01-01'],
+      isDark: false,
+      isLargeSeries: true,
+    });
+
+    const series = option.series as Array<Record<string, unknown>>;
+    expect(series[0].sampling).toBe('lttb');
+  });
+});
+
+// ============================================================
+// buildProfitChartOption
+// ============================================================
+describe('buildProfitChartOption', () => {
+  it('返回正确的 chart option 结构（含三条 series）', () => {
+    const option = buildProfitChartOption({
+      dates: ['2025-01-01', '2025-01-02'],
+      profitValues: [0, 500],
+      positiveAreaData: [0, 500],
+      negativeAreaData: [null, null],
+      isDark: false,
+      isLargeSeries: false,
+    });
+
+    expect(option.backgroundColor).toBe('transparent');
+    expect(Array.isArray(option.series)).toBe(true);
+    // 三条 series：主线 + 正面积 + 负面积
+    expect(option.series).toHaveLength(3);
+  });
+
+  it('收益主线包含零轴 markLine', () => {
+    const option = buildProfitChartOption({
+      dates: ['2025-01-01'],
+      profitValues: [0],
+      positiveAreaData: [0],
+      negativeAreaData: [null],
+      isDark: false,
+      isLargeSeries: false,
+    });
+
+    const series = option.series as Array<Record<string, unknown>>;
+    expect(series[0].markLine).toBeDefined();
+    const markLine = series[0].markLine as Record<string, unknown>;
+    const data = markLine.data as Array<Record<string, unknown>>;
+    expect(data[0].yAxis).toBe(0);
+  });
+});

--- a/utils/__tests__/totalAssetsChartUtils.test.ts
+++ b/utils/__tests__/totalAssetsChartUtils.test.ts
@@ -1,75 +1,34 @@
 /// <reference types="vitest/globals" />
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-
-const { mockFetchEastMoneyPingzhongData, mockWithCache } = vi.hoisted(() => ({
-  mockFetchEastMoneyPingzhongData: vi.fn(),
-  mockWithCache: vi.fn(),
-}));
-
-vi.mock('../../services/api', () => ({
-  fetchEastMoneyPingzhongData: mockFetchEastMoneyPingzhongData,
-  withCache: mockWithCache,
-}));
+import { describe, expect, it } from 'vitest';
 
 import {
   computeTimeRangeCutoff,
   filterDataByTimeRange,
   rebaseDataToFirstValue,
-  aggregateTotalAssetsHistory,
+  snapshotsToChartData,
   buildTotalAssetsChartOption,
   buildProfitChartOption,
   type TotalAssetsChartDataPoint,
 } from '../totalAssetsChartUtils';
 
-import type { Fund } from '../../types';
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockWithCache.mockImplementation(async <T>({ fetcher }: { fetcher: () => Promise<T> }) =>
-    fetcher(),
-  );
-});
+import type { TotalAssetsSnapshot } from '../../types';
 
 // ============================================================
-// computeTimeRangeCutoff
+// computeTimeRangeCutoff（返回日期字符串）
 // ============================================================
 describe('computeTimeRangeCutoff', () => {
-  it('1M 返回约 1 个月前的日期', () => {
-    const now = new Date();
+  it('1M 返回到 1 个月前的日期字符串', () => {
     const cutoff = computeTimeRangeCutoff('1M');
+    expect(cutoff).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const now = new Date();
     const expected = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
-    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
-    expect(cutoff.getMonth()).toBe(expected.getMonth());
-    expect(cutoff.getDate()).toBe(expected.getDate());
+    const expectedStr = `${expected.getFullYear()}-${String(expected.getMonth() + 1).padStart(2, '0')}-${String(expected.getDate()).padStart(2, '0')}`;
+    expect(cutoff).toBe(expectedStr);
   });
 
-  it('3M 返回约 3 个月前的日期', () => {
-    const now = new Date();
-    const cutoff = computeTimeRangeCutoff('3M');
-    const expected = new Date(now.getFullYear(), now.getMonth() - 3, now.getDate());
-    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
-    expect(cutoff.getMonth()).toBe(expected.getMonth());
-  });
-
-  it('6M 返回约 6 个月前的日期', () => {
-    const now = new Date();
-    const cutoff = computeTimeRangeCutoff('6M');
-    const expected = new Date(now.getFullYear(), now.getMonth() - 6, now.getDate());
-    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
-    expect(cutoff.getMonth()).toBe(expected.getMonth());
-  });
-
-  it('1Y 返回约 1 年前的日期', () => {
-    const now = new Date();
-    const cutoff = computeTimeRangeCutoff('1Y');
-    const expected = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
-    expect(cutoff.getFullYear()).toBe(expected.getFullYear());
-    expect(cutoff.getMonth()).toBe(expected.getMonth());
-  });
-
-  it('ALL 返回 epoch 日期', () => {
+  it('ALL 返回极早日期', () => {
     const cutoff = computeTimeRangeCutoff('ALL');
-    expect(cutoff.getTime()).toBe(0);
+    expect(cutoff).toBe('0000-01-01');
   });
 });
 
@@ -91,17 +50,15 @@ describe('filterDataByTimeRange', () => {
 
   it('1Y 过滤掉超过一年的数据', () => {
     const filtered = filterDataByTimeRange(data, '1Y');
-    // 只有最近一年的数据（从今天算约往前一年）
-    expect(filtered.length).toBeGreaterThanOrEqual(0);
-    expect(filtered.length).toBeLessThanOrEqual(4);
+    // 只有最近一年的数据（从今天算）
+    expect(filtered.length).toBeGreaterThanOrEqual(1);
+    // 确保 filtered 中的所有日期都不早于约一年前
     if (filtered.length > 0) {
-      // 确保 filtered 中的所有日期都不早于一年前的今天
       const oneYearAgo = new Date();
       oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+      const cutoff = `${oneYearAgo.getFullYear()}-${String(oneYearAgo.getMonth() + 1).padStart(2, '0')}-${String(oneYearAgo.getDate()).padStart(2, '0')}`;
       for (const d of filtered) {
-        expect(new Date(d.date).getTime()).toBeGreaterThanOrEqual(
-          new Date(oneYearAgo.getFullYear(), oneYearAgo.getMonth(), oneYearAgo.getDate()).getTime(),
-        );
+        expect(d.date >= cutoff).toBe(true);
       }
     }
   });
@@ -141,135 +98,37 @@ describe('rebaseDataToFirstValue', () => {
 });
 
 // ============================================================
-// aggregateTotalAssetsHistory
+// snapshotsToChartData
 // ============================================================
-describe('aggregateTotalAssetsHistory', () => {
-  const baseFund: Fund = {
-    code: '000001',
-    name: '测试基金A',
-    platform: '支付宝',
-    holdingShares: 100,
-    costPrice: 1.0,
-    currentNav: 1.2,
-    lastUpdate: '2026-05-09',
-    dayChangePct: 0.5,
-    dayChangeVal: 0.05,
-  };
-
-  it('空 funds 返回空数组', async () => {
-    const result = await aggregateTotalAssetsHistory([]);
-    expect(result).toEqual([]);
-  });
-
-  it('所有基金 holdingShares 为 0 时返回空数组', async () => {
-    const result = await aggregateTotalAssetsHistory([{ ...baseFund, holdingShares: 0 }]);
-    expect(result).toEqual([]);
-  });
-
-  it('双基金重叠日期聚合正确', async () => {
-    mockFetchEastMoneyPingzhongData
-      .mockResolvedValueOnce({
-        netWorthTrend: [
-          { x: new Date('2025-01-01').getTime(), y: 1.0, equityReturn: 0, unitMoney: '' },
-          { x: new Date('2025-01-02').getTime(), y: 1.1, equityReturn: 0, unitMoney: '' },
-        ],
-      })
-      .mockResolvedValueOnce({
-        netWorthTrend: [
-          { x: new Date('2025-01-01').getTime(), y: 2.0, equityReturn: 0, unitMoney: '' },
-          { x: new Date('2025-01-02').getTime(), y: 2.2, equityReturn: 0, unitMoney: '' },
-        ],
-      });
-
-    const funds: Fund[] = [
-      { ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 },
-      { ...baseFund, code: '000002', holdingShares: 50, costPrice: 2.0 },
+describe('snapshotsToChartData', () => {
+  it('将 DB 快照转换为图表数据点', () => {
+    const snapshots: TotalAssetsSnapshot[] = [
+      {
+        date: '2026-05-10',
+        totalAssets: 100000,
+        holdingGain: 5000,
+        holdingGainPct: 5.26,
+        dayGain: 1200,
+      },
+      {
+        date: '2026-05-11',
+        totalAssets: 102000,
+        holdingGain: 7000,
+        holdingGainPct: 7.37,
+        dayGain: 2000,
+      },
     ];
-
-    const result = await aggregateTotalAssetsHistory(funds);
-
+    const result = snapshotsToChartData(snapshots);
     expect(result).toHaveLength(2);
-    // 2025-01-01: 100*1.0 + 50*2.0 = 200
-    expect(result[0].date).toBe('2025-01-01');
-    expect(result[0].totalAssets).toBe(200);
-    expect(result[0].profit).toBe(0); // 200 - (100*1 + 50*2) = 0
-    // 2025-01-02: 100*1.1 + 50*2.2 = 220
-    expect(result[1].date).toBe('2025-01-02');
-    expect(result[1].totalAssets).toBe(220);
-    expect(result[1].profit).toBe(20); // 220 - 200 = 20
+    expect(result[0].date).toBe('2026-05-10');
+    expect(result[0].totalAssets).toBe(100000);
+    expect(result[0].profit).toBe(5000);
+    expect(result[1].profit).toBe(7000);
   });
 
-  it('基金返回 null 时跳过该基金，使用其他基金数据', async () => {
-    mockFetchEastMoneyPingzhongData.mockResolvedValueOnce(null).mockResolvedValueOnce({
-      netWorthTrend: [
-        { x: new Date('2025-01-01').getTime(), y: 2.0, equityReturn: 0, unitMoney: '' },
-      ],
-    });
-
-    const funds: Fund[] = [
-      { ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 },
-      { ...baseFund, code: '000002', holdingShares: 50, costPrice: 2.0 },
-    ];
-
-    const result = await aggregateTotalAssetsHistory(funds);
-
-    expect(result).toHaveLength(1);
-    // 只有基金B的数据：50 * 2.0 = 100
-    expect(result[0].totalAssets).toBe(100);
-    // profit = 100 - (100*1 + 50*2) = 100 - 200 = -100
-    expect(result[0].profit).toBe(-100);
-  });
-
-  it('不同日期范围前向填充', async () => {
-    // 基金A 只有 1月1日 和 1月3日 的数据，基金B 有 1月1日 到 1月3日
-    mockFetchEastMoneyPingzhongData
-      .mockResolvedValueOnce({
-        netWorthTrend: [
-          { x: new Date('2025-01-01').getTime(), y: 1.0, equityReturn: 0, unitMoney: '' },
-          { x: new Date('2025-01-03').getTime(), y: 1.5, equityReturn: 0, unitMoney: '' },
-        ],
-      })
-      .mockResolvedValueOnce({
-        netWorthTrend: [
-          { x: new Date('2025-01-01').getTime(), y: 2.0, equityReturn: 0, unitMoney: '' },
-          { x: new Date('2025-01-02').getTime(), y: 2.1, equityReturn: 0, unitMoney: '' },
-          { x: new Date('2025-01-03').getTime(), y: 2.3, equityReturn: 0, unitMoney: '' },
-        ],
-      });
-
-    const funds: Fund[] = [
-      { ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 },
-      { ...baseFund, code: '000002', holdingShares: 50, costPrice: 2.0 },
-    ];
-
-    const result = await aggregateTotalAssetsHistory(funds);
-
-    expect(result).toHaveLength(3);
-    // 2025-01-01: 100*1.0 + 50*2.0 = 200
-    expect(result[0].totalAssets).toBe(200);
-    // 2025-01-02: 100*1.0(forward-fill) + 50*2.1 = 205
-    expect(result[1].totalAssets).toBe(205);
-    // 2025-01-03: 100*1.5 + 50*2.3 = 265
-    expect(result[2].totalAssets).toBe(265);
-  });
-
-  it('使用 withCache 缓存结果', async () => {
-    mockFetchEastMoneyPingzhongData.mockResolvedValue({
-      netWorthTrend: [
-        { x: new Date('2025-01-01').getTime(), y: 1.0, equityReturn: 0, unitMoney: '' },
-      ],
-    });
-
-    const funds: Fund[] = [{ ...baseFund, code: '000001', holdingShares: 100, costPrice: 1.0 }];
-
-    await aggregateTotalAssetsHistory(funds);
-
-    expect(mockWithCache).toHaveBeenCalledWith(
-      expect.objectContaining({
-        key: expect.stringContaining('total-assets:'),
-        ttlMs: 30 * 60 * 1000,
-      }),
-    );
+  it('空快照返回空数组', () => {
+    const result = snapshotsToChartData([]);
+    expect(result).toEqual([]);
   });
 });
 
@@ -326,7 +185,6 @@ describe('buildProfitChartOption', () => {
 
     expect(option.backgroundColor).toBe('transparent');
     expect(Array.isArray(option.series)).toBe(true);
-    // 三条 series：主线 + 正面积 + 负面积
     expect(option.series).toHaveLength(3);
   });
 

--- a/utils/totalAssetsChartUtils.ts
+++ b/utils/totalAssetsChartUtils.ts
@@ -1,0 +1,394 @@
+import * as echarts from 'echarts';
+import { fetchEastMoneyPingzhongData, withCache } from '../services/api';
+import type { Fund } from '../types';
+
+export type TimeRange = '1M' | '3M' | '6M' | '1Y' | 'ALL';
+
+export type TotalAssetsChartDataPoint = {
+  date: string;
+  totalAssets: number;
+  profit: number;
+};
+
+const timestampToDateStr = (ts: number): string => {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+};
+
+export const computeTimeRangeCutoff = (range: TimeRange): Date => {
+  const now = new Date();
+  switch (range) {
+    case '1M':
+      return new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+    case '3M':
+      return new Date(now.getFullYear(), now.getMonth() - 3, now.getDate());
+    case '6M':
+      return new Date(now.getFullYear(), now.getMonth() - 6, now.getDate());
+    case '1Y':
+      return new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+    case 'ALL':
+      return new Date(0);
+  }
+};
+
+export const filterDataByTimeRange = (
+  data: TotalAssetsChartDataPoint[],
+  range: TimeRange,
+): TotalAssetsChartDataPoint[] => {
+  if (range === 'ALL') return data;
+  const cutoffStr = timestampToDateStr(computeTimeRangeCutoff(range).getTime());
+  return data.filter((d) => d.date >= cutoffStr);
+};
+
+export const aggregateTotalAssetsHistory = async (
+  funds: Fund[],
+): Promise<TotalAssetsChartDataPoint[]> => {
+  const activeFunds = funds.filter((f) => f.holdingShares > 0);
+  if (activeFunds.length === 0) return [];
+
+  const totalCost = activeFunds.reduce((sum, f) => sum + f.holdingShares * f.costPrice, 0);
+
+  const codesKey = activeFunds
+    .map((f) => `${f.code}:${f.holdingShares.toFixed(2)}`)
+    .sort()
+    .join(',');
+
+  return withCache({
+    key: `total-assets:${codesKey}`,
+    ttlMs: 30 * 60 * 1000,
+    fetcher: async () => {
+      const promises = activeFunds.map((f) =>
+        fetchEastMoneyPingzhongData(f.code).then((result) => ({ fund: f, result })),
+      );
+      const results = await Promise.all(promises);
+
+      // 为每只基金建立 date → nav 的排序 Map
+      const fundNavMaps: Array<{ sortedDates: string[]; navByDate: Map<string, number> }> = [];
+      const allDatesSet = new Set<string>();
+
+      for (const { fund, result } of results) {
+        const navByDate = new Map<string, number>();
+        if (result?.netWorthTrend?.length) {
+          for (const point of result.netWorthTrend) {
+            const dateStr = timestampToDateStr(point.x);
+            navByDate.set(dateStr, point.y);
+            allDatesSet.add(dateStr);
+          }
+        } else {
+          console.warn(`无法获取 ${fund.code} ${fund.name} 的历史净值数据`);
+        }
+        const sortedDates = Array.from(navByDate.keys()).sort();
+        fundNavMaps.push({ sortedDates, navByDate });
+      }
+
+      if (allDatesSet.size === 0) return [];
+
+      const allDates = Array.from(allDatesSet).sort();
+
+      // 聚合：对每个日期，累加每只基金的持仓市值
+      const dataPoints: TotalAssetsChartDataPoint[] = [];
+
+      for (const date of allDates) {
+        let totalAssets = 0;
+        for (let fi = 0; fi < activeFunds.length; fi++) {
+          const fund = activeFunds[fi];
+          const { sortedDates, navByDate } = fundNavMaps[fi];
+
+          // 在该基金的日期列表中查找 <= 当前日期的最近日期（前向填充）
+          let nav: number | null = null;
+          for (let di = sortedDates.length - 1; di >= 0; di--) {
+            if (sortedDates[di] <= date) {
+              nav = navByDate.get(sortedDates[di]) ?? null;
+              break;
+            }
+          }
+
+          if (nav !== null) {
+            totalAssets += fund.holdingShares * nav;
+          }
+          // 基金尚未成立（当前日期前无 NAV）→ 贡献为 0
+        }
+
+        dataPoints.push({
+          date,
+          totalAssets: Math.round(totalAssets * 100) / 100,
+          profit: Math.round((totalAssets - totalCost) * 100) / 100,
+        });
+      }
+
+      return dataPoints;
+    },
+  });
+};
+
+export const rebaseDataToFirstValue = (
+  data: TotalAssetsChartDataPoint[],
+): {
+  dates: string[];
+  values: number[];
+} => {
+  if (data.length === 0) return { dates: [], values: [] };
+  const base = data[0].totalAssets;
+  const dates = data.map((d) => d.date);
+  const values = data.map((d) =>
+    base > 0 ? Math.round((d.totalAssets / base - 1) * 100 * 100) / 100 : 0,
+  );
+  return { dates, values };
+};
+
+// === 图表 Option 构建器 ===
+
+export type AssetsChartDataPoint = {
+  value: number;
+  totalAssets: number;
+  profit: number;
+};
+
+type BuildTotalAssetsChartOptionParams = {
+  data: AssetsChartDataPoint[];
+  dates: string[];
+  isDark: boolean;
+  isLargeSeries: boolean;
+};
+
+export const buildTotalAssetsChartOption = ({
+  data,
+  dates,
+  isDark,
+  isLargeSeries,
+}: BuildTotalAssetsChartOptionParams): echarts.EChartsOption => {
+  const startStr = dates[0] ?? '';
+  const endStr = dates[dates.length - 1] ?? '';
+
+  return {
+    title: {
+      text: dates.length > 0 ? `${startStr} 至 ${endStr}` : '',
+      left: '0%',
+      top: '0%',
+      textStyle: { fontSize: 12, color: isDark ? '#9ca3af' : '#666', fontWeight: 'normal' },
+    },
+    animation: !isLargeSeries,
+    animationDuration: !isLargeSeries ? 300 : 0,
+    animationEasing: 'cubicOut',
+    backgroundColor: 'transparent',
+    grid: { left: 20, right: 10, bottom: 30, top: 30, containLabel: true },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+        label: { backgroundColor: isDark ? '#374151' : '#6b7280', fontFamily: 'monospace' },
+        crossStyle: { color: '#9ca3af', type: 'dashed' },
+      },
+      backgroundColor: isDark ? 'rgba(31, 41, 55, 0.95)' : 'rgba(255, 255, 255, 0.95)',
+      borderColor: isDark ? '#374151' : '#eee',
+      borderWidth: 1,
+      padding: [8, 12],
+      textStyle: { color: isDark ? '#f3f4f6' : '#333', fontSize: 12 },
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: dates,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: {
+        interval: 'auto',
+        color: isDark ? '#9ca3af' : '#999',
+        fontSize: 10,
+        formatter: (value: string) => value.substring(2),
+      },
+    },
+    yAxis: {
+      type: 'value',
+      position: 'right',
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: {
+        show: true,
+        lineStyle: { color: isDark ? '#374151' : '#f3f4f6', type: 'dashed', width: 1 },
+      },
+      axisLabel: {
+        show: true,
+        inside: false,
+        color: isDark ? '#9ca3af' : '#9ca3af',
+        fontSize: 10,
+        formatter: (val: number) => `${val.toFixed(0)}%`,
+      },
+    },
+    series: [
+      {
+        name: '总资产',
+        type: 'line',
+        data,
+        showSymbol: false,
+        symbol: 'circle',
+        symbolSize: 6,
+        smooth: true,
+        sampling: isLargeSeries ? 'lttb' : undefined,
+        progressive: isLargeSeries ? 300 : undefined,
+        progressiveThreshold: isLargeSeries ? 500 : undefined,
+        lineStyle: { width: 2, color: '#f87171' },
+        itemStyle: { color: '#f87171', borderColor: '#fff', borderWidth: 1 },
+        areaStyle: {
+          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+            { offset: 0, color: isDark ? 'rgba(0,0,0,0)' : 'rgba(255,255,255,0)' },
+            { offset: 1, color: '#f87171' },
+          ]),
+          opacity: 0.15,
+        },
+        z: 3,
+      },
+    ],
+  };
+};
+
+export type ProfitChartDataPoint = {
+  value: number;
+  label: string;
+};
+
+type BuildProfitChartOptionParams = {
+  dates: string[];
+  profitValues: number[];
+  positiveAreaData: Array<number | null>;
+  negativeAreaData: Array<number | null>;
+  isDark: boolean;
+  isLargeSeries: boolean;
+};
+
+export const buildProfitChartOption = ({
+  dates,
+  profitValues,
+  positiveAreaData,
+  negativeAreaData,
+  isDark,
+  isLargeSeries,
+}: BuildProfitChartOptionParams): echarts.EChartsOption => {
+  const startStr = dates[0] ?? '';
+  const endStr = dates[dates.length - 1] ?? '';
+
+  return {
+    title: {
+      text: dates.length > 0 ? `${startStr} 至 ${endStr}` : '',
+      left: '0%',
+      top: '0%',
+      textStyle: { fontSize: 12, color: isDark ? '#9ca3af' : '#666', fontWeight: 'normal' },
+    },
+    animation: !isLargeSeries,
+    animationDuration: !isLargeSeries ? 300 : 0,
+    animationEasing: 'cubicOut',
+    backgroundColor: 'transparent',
+    grid: { left: 20, right: 10, bottom: 30, top: 30, containLabel: true },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+        label: { backgroundColor: isDark ? '#374151' : '#6b7280', fontFamily: 'monospace' },
+        crossStyle: { color: '#9ca3af', type: 'dashed' },
+      },
+      backgroundColor: isDark ? 'rgba(31, 41, 55, 0.95)' : 'rgba(255, 255, 255, 0.95)',
+      borderColor: isDark ? '#374151' : '#eee',
+      borderWidth: 1,
+      padding: [8, 12],
+      textStyle: { color: isDark ? '#f3f4f6' : '#333', fontSize: 12 },
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: dates,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: {
+        interval: 'auto',
+        color: isDark ? '#9ca3af' : '#999',
+        fontSize: 10,
+        formatter: (value: string) => value.substring(2),
+      },
+    },
+    yAxis: {
+      type: 'value',
+      position: 'right',
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: {
+        show: true,
+        lineStyle: { color: isDark ? '#374151' : '#f3f4f6', type: 'dashed', width: 1 },
+      },
+      axisLabel: {
+        show: true,
+        inside: false,
+        color: isDark ? '#9ca3af' : '#9ca3af',
+        fontSize: 10,
+        formatter: (val: number) => {
+          const abs = Math.abs(val);
+          if (abs >= 1e6) return `${(val / 1e6).toFixed(1)}M`;
+          if (abs >= 1e4) return `${(val / 1e4).toFixed(1)}万`;
+          return `${val.toFixed(0)}`;
+        },
+      },
+    },
+    series: [
+      {
+        name: '收益',
+        type: 'line',
+        data: profitValues,
+        showSymbol: false,
+        symbol: 'circle',
+        symbolSize: 6,
+        smooth: true,
+        sampling: isLargeSeries ? 'lttb' : undefined,
+        progressive: isLargeSeries ? 300 : undefined,
+        progressiveThreshold: isLargeSeries ? 500 : undefined,
+        lineStyle: { width: 2, color: '#f87171' },
+        itemStyle: { color: '#f87171', borderColor: '#fff', borderWidth: 1 },
+        z: 3,
+        markLine: {
+          silent: true,
+          symbol: 'none',
+          label: {
+            show: true,
+            position: 'insideEndTop',
+            formatter: '零轴',
+            color: isDark ? '#9ca3af' : '#6b7280',
+            fontSize: 10,
+            padding: [0, 4],
+          },
+          lineStyle: {
+            color: isDark ? '#6b7280' : '#9ca3af',
+            type: 'dashed',
+            width: 1,
+          },
+          data: [{ yAxis: 0 }],
+        },
+      },
+      {
+        name: '',
+        type: 'line',
+        data: positiveAreaData,
+        showSymbol: false,
+        smooth: true,
+        sampling: isLargeSeries ? 'lttb' : undefined,
+        progressive: isLargeSeries ? 300 : undefined,
+        progressiveThreshold: isLargeSeries ? 500 : undefined,
+        lineStyle: { width: 0, opacity: 0 },
+        areaStyle: { color: '#f87171', opacity: 0.2 },
+        tooltip: { show: false },
+        z: 2,
+      },
+      {
+        name: '',
+        type: 'line',
+        data: negativeAreaData,
+        showSymbol: false,
+        smooth: true,
+        sampling: isLargeSeries ? 'lttb' : undefined,
+        progressive: isLargeSeries ? 300 : undefined,
+        progressiveThreshold: isLargeSeries ? 500 : undefined,
+        lineStyle: { width: 0, opacity: 0 },
+        areaStyle: { color: '#34d399', opacity: 0.2 },
+        tooltip: { show: false },
+        z: 2,
+      },
+    ],
+  };
+};

--- a/utils/totalAssetsChartUtils.ts
+++ b/utils/totalAssetsChartUtils.ts
@@ -1,6 +1,5 @@
 import * as echarts from 'echarts';
-import { fetchEastMoneyPingzhongData, withCache } from '../services/api';
-import type { Fund } from '../types';
+import type { TotalAssetsSnapshot } from '../types';
 
 export type TimeRange = '1M' | '3M' | '6M' | '1Y' | 'ALL';
 
@@ -10,25 +9,26 @@ export type TotalAssetsChartDataPoint = {
   profit: number;
 };
 
-const timestampToDateStr = (ts: number): string => {
-  const d = new Date(ts);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-};
-
-export const computeTimeRangeCutoff = (range: TimeRange): Date => {
+export const computeTimeRangeCutoff = (range: TimeRange): string => {
   const now = new Date();
+  let cutoff: Date;
   switch (range) {
     case '1M':
-      return new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+      cutoff = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+      break;
     case '3M':
-      return new Date(now.getFullYear(), now.getMonth() - 3, now.getDate());
+      cutoff = new Date(now.getFullYear(), now.getMonth() - 3, now.getDate());
+      break;
     case '6M':
-      return new Date(now.getFullYear(), now.getMonth() - 6, now.getDate());
+      cutoff = new Date(now.getFullYear(), now.getMonth() - 6, now.getDate());
+      break;
     case '1Y':
-      return new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+      cutoff = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+      break;
     case 'ALL':
-      return new Date(0);
+      return '0000-01-01';
   }
+  return `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`;
 };
 
 export const filterDataByTimeRange = (
@@ -36,89 +36,19 @@ export const filterDataByTimeRange = (
   range: TimeRange,
 ): TotalAssetsChartDataPoint[] => {
   if (range === 'ALL') return data;
-  const cutoffStr = timestampToDateStr(computeTimeRangeCutoff(range).getTime());
+  const cutoffStr = computeTimeRangeCutoff(range);
   return data.filter((d) => d.date >= cutoffStr);
 };
 
-export const aggregateTotalAssetsHistory = async (
-  funds: Fund[],
-): Promise<TotalAssetsChartDataPoint[]> => {
-  const activeFunds = funds.filter((f) => f.holdingShares > 0);
-  if (activeFunds.length === 0) return [];
-
-  const totalCost = activeFunds.reduce((sum, f) => sum + f.holdingShares * f.costPrice, 0);
-
-  const codesKey = activeFunds
-    .map((f) => `${f.code}:${f.holdingShares.toFixed(2)}`)
-    .sort()
-    .join(',');
-
-  return withCache({
-    key: `total-assets:${codesKey}`,
-    ttlMs: 30 * 60 * 1000,
-    fetcher: async () => {
-      const promises = activeFunds.map((f) =>
-        fetchEastMoneyPingzhongData(f.code).then((result) => ({ fund: f, result })),
-      );
-      const results = await Promise.all(promises);
-
-      // 为每只基金建立 date → nav 的排序 Map
-      const fundNavMaps: Array<{ sortedDates: string[]; navByDate: Map<string, number> }> = [];
-      const allDatesSet = new Set<string>();
-
-      for (const { fund, result } of results) {
-        const navByDate = new Map<string, number>();
-        if (result?.netWorthTrend?.length) {
-          for (const point of result.netWorthTrend) {
-            const dateStr = timestampToDateStr(point.x);
-            navByDate.set(dateStr, point.y);
-            allDatesSet.add(dateStr);
-          }
-        } else {
-          console.warn(`无法获取 ${fund.code} ${fund.name} 的历史净值数据`);
-        }
-        const sortedDates = Array.from(navByDate.keys()).sort();
-        fundNavMaps.push({ sortedDates, navByDate });
-      }
-
-      if (allDatesSet.size === 0) return [];
-
-      const allDates = Array.from(allDatesSet).sort();
-
-      // 聚合：对每个日期，累加每只基金的持仓市值
-      const dataPoints: TotalAssetsChartDataPoint[] = [];
-
-      for (const date of allDates) {
-        let totalAssets = 0;
-        for (let fi = 0; fi < activeFunds.length; fi++) {
-          const fund = activeFunds[fi];
-          const { sortedDates, navByDate } = fundNavMaps[fi];
-
-          // 在该基金的日期列表中查找 <= 当前日期的最近日期（前向填充）
-          let nav: number | null = null;
-          for (let di = sortedDates.length - 1; di >= 0; di--) {
-            if (sortedDates[di] <= date) {
-              nav = navByDate.get(sortedDates[di]) ?? null;
-              break;
-            }
-          }
-
-          if (nav !== null) {
-            totalAssets += fund.holdingShares * nav;
-          }
-          // 基金尚未成立（当前日期前无 NAV）→ 贡献为 0
-        }
-
-        dataPoints.push({
-          date,
-          totalAssets: Math.round(totalAssets * 100) / 100,
-          profit: Math.round((totalAssets - totalCost) * 100) / 100,
-        });
-      }
-
-      return dataPoints;
-    },
-  });
+/** 将 DB 快照转换为图表数据点（profit = holdingGain） */
+export const snapshotsToChartData = (
+  snapshots: TotalAssetsSnapshot[],
+): TotalAssetsChartDataPoint[] => {
+  return snapshots.map((s) => ({
+    date: s.date,
+    totalAssets: s.totalAssets,
+    profit: s.holdingGain,
+  }));
 };
 
 export const rebaseDataToFirstValue = (


### PR DESCRIPTION
## Summary
- 点击 Dashboard 总资产数字打开 TotalAssetsModal，展示历史总资产曲线和收益曲线
- 支持 1M / 3M / 6M / 1Y / ALL 时间范围切换
- 数据源：逐基金拉取东方财富历史 NAV，聚合为持仓总资产时间序列
- 使用 ModalShell 统一封装，ECharts 渲染图表

## Changes
- **新建** `utils/totalAssetsChartUtils.ts` — 聚合逻辑 + ECharts option 构建器
- **新建** `components/TotalAssetsModal.tsx` — Modal 组件
- **新建** 对应测试文件（33 个测试用例）
- **修改** `Dashboard.tsx` — 总资产数字变可点击按钮，渲染 Modal
- **修改** `services/api.ts` — 导出 `withCache` 供 utils 复用
- **修改** `services/i18n.tsx` — 新增 `totalAssets` 翻译 key

## Test plan
- [x] `npm run lint` 零警告
- [x] `npm run test` 402 测试全过
- [ ] `npm run dev` 手动验证 Modal 打开/关闭/图表/时间范围